### PR TITLE
Fix code block text invisible in light themes

### DIFF
--- a/frontend/src/components/markdown/Markdown.jsx
+++ b/frontend/src/components/markdown/Markdown.jsx
@@ -26,7 +26,7 @@ function CodeBlock({ className, children }) {
         {copied ? <Check size={14} /> : <Copy size={14} />}
       </button>
       <pre className="overflow-x-auto rounded-lg bg-[#0d1117] p-4 text-sm">
-        <code className={className}>{children}</code>
+        <code className={`${className || ''} !text-[#e6edf3]`}>{children}</code>
       </pre>
     </div>
   )


### PR DESCRIPTION
## Summary
Fixes #1 — text inside fenced code blocks is invisible in light themes (e.g. Phlox Light, Fred Hutch, Light, Sandstone).

## Root cause
`CodeBlock` in `frontend/src/components/markdown/Markdown.jsx` renders code on a permanently dark `<pre>` background (`bg-[#0d1117]`). The code text color, however, is governed by the `@tailwindcss/typography` rule `prose-code:text-content`, which resolves to the theme's `--color-text`. In light themes that variable is a dark color (e.g. `#2a1438`, `#111827`), producing dark text on the dark code-block background — so plain/untokenized code becomes unreadable. The highlight.js token colors (`.hljs-*`) still show, but base text does not.

## Fix
Pin the code element's text color to the light base used by the highlight.js theme (`#e6edf3`, matching the `.hljs` rule in `index.css`), using Tailwind's `!important` arbitrary value so it overrides `prose-code:text-content`:

```diff
- <code className={className}>{children}</code>
+ <code className={`${className || ''} !text-[#e6edf3]`}>{children}</code>
```

Highlight.js token colors remain intact since they target more specific `.hljs-*` classes.

## Verification
- Tailwind v3.4.15 supports the `!` important prefix and arbitrary `text-[#hex]` values; `content` globs cover `src/**/*.{js,jsx}`.
- `npm run build` succeeds; confirmed the compiled CSS contains `.!text-[#e6edf3]{ ... !important; color:#e6edf3 }`.
- Code blocks now readable across all light and dark themes.
