### PR TITLE
Keep activity indicator visible between tool steps (#3)

### DIFF
--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -36,16 +36,26 @@ function Welcome() {
   )
 }
 
-function ThinkingDots() {
+// True while at least one tool call is still executing (no result yet).
+// Those cards render their own spinner, so the page-level indicator yields to them;
+// in the gaps between tool steps (all results in, next step not started) it stays visible.
+function anyToolRunning(live) {
+  return live.toolCalls.some((tc) => tc.content === null)
+}
+
+function ThinkingDots({ label }) {
   return (
-    <div className="flex gap-1.5 px-1 py-2">
-      {[0, 1, 2].map((i) => (
-        <span
-          key={i}
-          className="hc-dot h-2 w-2 rounded-full bg-accent"
-          style={{ animationDelay: `${i * 0.16}s` }}
-        />
-      ))}
+    <div className="flex items-center gap-2 px-1 py-2" role="status" aria-live="polite">
+      <div className="flex gap-1.5">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="hc-dot h-2 w-2 rounded-full bg-accent"
+            style={{ animationDelay: `${i * 0.16}s` }}
+          />
+        ))}
+      </div>
+      <span className="text-sm text-muted">{label || 'Working\u2026'}</span>
     </div>
   )
 }
@@ -103,11 +113,8 @@ export default function ChatPage() {
               </>
             )}
 
-            {streaming && live && !live.content && live.toolCalls.length === 0 && (
-              <div className="flex flex-col gap-1">
-                {live.status && <span className="px-1 text-sm text-accent">{live.status}</span>}
-                <ThinkingDots />
-              </div>
+            {streaming && live && !live.pendingApproval && !anyToolRunning(live) && (
+              <ThinkingDots label={live.status || (live.content ? 'Responding\u2026' : 'Working\u2026')} />
             )}
 
             {error && (


### PR DESCRIPTION
## Problem

Closes #3.

When chatting, the animated "thinking dots" gave a clear *working* signal — but only **before the first tool call**. The render condition in `ChatPage.jsx` was:

```jsx
streaming && live && !live.content && live.toolCalls.length === 0
```

Once any tool call existed, this went false. So in the window **after a tool's `tool_result` arrived** (its card flips to "done") and **before the next `tool_call` or first answer `token`**, nothing on screen animated even though the model was busy. On long multi-tool turns this felt like the system had hung.

## Fix

Make the page-level indicator persistent across the whole streaming turn, yielding only when another element is already signaling activity:

```jsx
streaming && live && !live.pendingApproval && !anyToolRunning(live)
```

- New `anyToolRunning(live)` helper — while a tool is mid-execution, the existing per-tool spinner in `ToolCallCard` covers it, so the page indicator steps aside to avoid double indicators.
- During an approval prompt, the prompt itself is shown instead.
- In the **between-step gap** (all results in, next step not started), the indicator now stays visible. This is the actual fix.
- `ThinkingDots` now takes a contextual `label`: live `status` text if present, else `Responding…` once answer tokens stream, else `Working…`.
- Added `role="status"` / `aria-live="polite"` for screen-reader announcement.

## Behavior

| Phase | Indicator |
|---|---|
| Before first tool | `Working…` |
| Tool actively running | hidden (tool card spinner shows) |
| Between tool steps | `Working…` (the fix) |
| Answer streaming | `Responding…` |
| Awaiting approval | hidden (approval prompt shown) |

## Testing

`npm run build` passes. Change is contained to `frontend/src/pages/ChatPage.jsx` (+21 / −14); reuses the existing `status` SSE event and tool-card spinner rather than duplicating them.