### PR TITLE
added search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ models).
   **LaTeX math**.
 - 🤖 **Agentic harness** (inspired by PI Coder): the model uses tools in a loop —
   filesystem (`read_file`/`write_file`/`edit_file`/`glob`/`grep`), `run_shell`,
-  `execute_python`/`execute_node`, `search_documents`, `web_fetch`, plus **planning**
-  (`update_todos`), **sub-agents** (`spawn_subagent`), **memory** (`save_memory`), and
-  **checkpoints** — each scoped to a per-conversation sandboxed workspace.
+  `execute_python`/`execute_node`, `search_documents`, opt-in live `web_search` +
+  `web_fetch`, plus **planning** (`update_todos`), **sub-agents** (`spawn_subagent`),
+  **memory** (`save_memory`), and **checkpoints** — each scoped to a per-conversation
+  sandboxed workspace.
 - 🤝 **Human-in-the-loop approvals** — pause on sensitive tools, approve/deny, resume.
 - 🧰 **Code execution** with captured output and **artifacts** shown inline + a
   **Workspace Files** panel to browse/download everything the agent created.
@@ -28,6 +29,9 @@ models).
 - 📚 **Documents / RAG** — upload PDF/DOCX/TXT/MD/code; **hybrid (dense+sparse) search**
   over **Qdrant** with reranking + citations; global or per-conversation scoping. Works
   offline via a fallback embedder.
+- 🌐 **Opt-in live web search** — a per-prompt composer toggle exposes `web_search`
+  backed by zero-config `ddgs` (or optional SearXNG), so the agent can discover current
+  sources before fetching pages with `web_fetch`.
 - 🧠 **Cross-conversation memory** — durable facts recalled across chats.
 - 🖼️ **Multimodal** — attach images to messages for vision models.
 - 🔌 **MCP integration** — connect Model Context Protocol servers; their tools join
@@ -52,6 +56,7 @@ models).
 - 🎨 **Theming** — Phlox Dark (default) + Phlox Light/Light/Dark/Fred Hutch/Hutch
   Night/Sandstone, instant switching. See [docs/THEMING.md](docs/THEMING.md).
 - 🛡️ **Per-tool permissions** — `auto | ask | deny`, with an "Agent mode" toggle.
+  Live web search is a separate per-prompt toggle and is off by default.
 
 ## Documentation
 

--- a/backend/app/agent/harness.py
+++ b/backend/app/agent/harness.py
@@ -199,7 +199,9 @@ class AgentSession:
         ask_batch: list[ToolCall] = []
 
         for call in calls:
-            if decisions is not None and call.id in decisions:
+            if self.allowed_tools is not None and call.name not in self.allowed_tools:
+                decision = "not_enabled"
+            elif decisions is not None and call.id in decisions:
                 decision = "allow" if decisions[call.id] == "allow" else "deny"
             else:
                 decision = self.gate.decide(call.name)
@@ -209,7 +211,12 @@ class AgentSession:
                 continue
 
             yield events.tool_call(call.id, call.name, call.arguments)
-            if decision == "deny":
+            if decision == "not_enabled":
+                result = ToolResult(
+                    content=f"Tool '{call.name}' is not enabled for this turn. Not executed.",
+                    is_error=True,
+                )
+            elif decision == "deny":
                 result = ToolResult(content=f"Tool '{call.name}' was denied. Not executed.", is_error=True)
             else:
                 yield events.status(f"Running {call.name}…")
@@ -240,6 +247,7 @@ class AgentSession:
             "params": self.params,
             "profile": self.profile,
             "model": self.model,
+            "allowed_tools": sorted(self.allowed_tools) if self.allowed_tools is not None else None,
         }
         pending = PendingApproval(conversation_id=self.conversation.id, state=state)
         self.db.add(pending)

--- a/backend/app/agent/tools/__init__.py
+++ b/backend/app/agent/tools/__init__.py
@@ -31,6 +31,7 @@ def register_builtin_tools(registry: "ToolRegistry") -> None:
         code.ExecutePython(),
         code.ExecuteNode(),
         docs.SearchDocuments(),
+        web.WebSearch(),
         web.WebFetch(),
         memory.SaveMemory(),
         subagent.SpawnSubagent(),

--- a/backend/app/agent/tools/web.py
+++ b/backend/app/agent/tools/web.py
@@ -1,12 +1,18 @@
-"""Web fetch tool (best-effort HTML→text)."""
+"""Web fetch/search tools."""
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
 from app.agent.tools.base import Tool, ToolContext, ToolResult
+from app.config import get_web_search_config
 
 MAX_CHARS = 20_000
+MAX_SEARCH_RESULTS = 10
+DEFAULT_SEARCH_RESULTS = 5
+MAX_SEARCH_TITLE_CHARS = 200
+MAX_SEARCH_SNIPPET_CHARS = 500
 
 
 def _html_to_text(html: str) -> str:
@@ -15,6 +21,35 @@ def _html_to_text(html: str) -> str:
     text = re.sub(r"&nbsp;", " ", text)
     text = re.sub(r"\s+", " ", text)
     return text.strip()
+
+
+def _clean_text(value: Any, max_chars: int) -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + " ... [truncated]"
+
+
+def _result_triplet(raw: dict[str, Any]) -> dict[str, str] | None:
+    url = str(raw.get("url") or raw.get("href") or raw.get("link") or "").strip()
+    if not url:
+        return None
+    return {
+        "title": _clean_text(raw.get("title") or raw.get("heading") or "(untitled)", MAX_SEARCH_TITLE_CHARS),
+        "url": url,
+        "snippet": _clean_text(
+            raw.get("snippet") or raw.get("body") or raw.get("content") or "",
+            MAX_SEARCH_SNIPPET_CHARS,
+        ),
+    }
+
+
+def _bounded_max_results(value: Any) -> int:
+    try:
+        requested = int(value)
+    except (TypeError, ValueError):
+        requested = DEFAULT_SEARCH_RESULTS
+    return max(1, min(requested, MAX_SEARCH_RESULTS))
 
 
 class WebFetch(Tool):
@@ -43,3 +78,91 @@ class WebFetch(Tool):
             return ToolResult(content=f"HTTP {resp.status_code} {url}\n\n{text}")
         except Exception as e:  # noqa: BLE001
             return ToolResult(content=f"Fetch failed: {e}", is_error=True)
+
+
+class WebSearch(Tool):
+    name = "web_search"
+    description = (
+        "Search the live web and return ranked results with titles, URLs, and snippets. "
+        "Use this to discover current sources, then call web_fetch on promising results."
+    )
+    category = "web"
+    default_permission = "auto"
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query"},
+            "max_results": {
+                "type": "integer",
+                "description": f"Maximum results to return (default {DEFAULT_SEARCH_RESULTS}, max {MAX_SEARCH_RESULTS})",
+            },
+        },
+        "required": ["query"],
+    }
+
+    def run(
+        self,
+        ctx: ToolContext,  # noqa: ARG002
+        query: str = "",
+        max_results: int = DEFAULT_SEARCH_RESULTS,
+        **_: Any,
+    ) -> ToolResult:
+        query = str(query or "").strip()
+        if not query:
+            return ToolResult(content="Search query is required.", is_error=True)
+
+        limit = _bounded_max_results(max_results)
+        cfg = get_web_search_config()
+        searxng_url = str(cfg.get("searxng_url") or "").strip()
+
+        try:
+            if searxng_url:
+                results = self._search_searxng(searxng_url, query, limit)
+                backend = "searxng"
+            else:
+                results = self._search_ddgs(query, limit)
+                backend = "ddgs"
+        except Exception as e:  # noqa: BLE001
+            return ToolResult(content=f"Web search failed: {e}", is_error=True)
+
+        payload = {
+            "query": query,
+            "backend": backend,
+            "results": results,
+        }
+        return ToolResult(content=json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def _search_ddgs(self, query: str, max_results: int) -> list[dict[str, str]]:
+        from ddgs import DDGS
+
+        with DDGS(timeout=20) as ddgs:
+            raw_results = ddgs.text(query, max_results=max_results)
+        return self._normalize_results(raw_results, max_results)
+
+    def _search_searxng(self, base_url: str, query: str, max_results: int) -> list[dict[str, str]]:
+        import httpx
+
+        resp = httpx.get(
+            f"{base_url.rstrip('/')}/search",
+            params={"q": query, "format": "json"},
+            headers={"Accept": "application/json", "User-Agent": "Phlox/0.1"},
+            timeout=20.0,
+            follow_redirects=True,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        raw_results = data.get("results", []) if isinstance(data, dict) else []
+        return self._normalize_results(raw_results, max_results)
+
+    def _normalize_results(self, raw_results: Any, max_results: int) -> list[dict[str, str]]:
+        results: list[dict[str, str]] = []
+        for raw in raw_results or []:
+            if not isinstance(raw, dict):
+                continue
+            triplet = _result_triplet(raw)
+            if triplet is None:
+                continue
+            results.append(triplet)
+            if len(results) >= max_results:
+                break
+        return results

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -127,6 +127,22 @@ def get_resilience_config() -> dict[str, Any]:
     return cfg
 
 
+def get_web_search_config() -> dict[str, Any]:
+    """Web search settings.
+
+    By default Phlox uses ddgs with no configuration. Set ``web_search.searxng_url`` in
+    config.yml, or the ``SEARXNG_URL`` environment variable, to use SearXNG instead.
+    """
+    cfg = dict(load_config().get("web_search", {}) or {})
+    env_url = os.environ.get("SEARXNG_URL")
+    if env_url:
+        cfg["searxng_url"] = env_url
+    elif cfg.get("SEARXNG_URL") and not cfg.get("searxng_url"):
+        cfg["searxng_url"] = cfg["SEARXNG_URL"]
+    cfg.setdefault("searxng_url", "")
+    return cfg
+
+
 def get_sandbox_config() -> dict[str, Any]:
     """Code/shell execution sandbox config. ``runner`` is ``local`` or ``container``.
 

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -149,8 +149,12 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), user: User = Depends(g
             yield events.status("Summarizing earlier context…")
 
         gate = PermissionGate(db, REGISTRY, auto_approve=req.auto_approve)
+        enabled_tools = gate.enabled_names()
+        if not req.web_search:
+            enabled_tools.discard("web_search")
         session = AgentSession(
             db, conversation, provider, REGISTRY, gate, params, profile, model,
+            allowed_tools=enabled_tools,
             fallback_provider=fallback,
         )
         yield from session.run(compacted)
@@ -189,9 +193,11 @@ def approve(req: ApproveRequest, db: Session = Depends(get_db), user: User = Dep
             return
 
         gate = PermissionGate(db, REGISTRY, auto_approve=False)
+        allowed_tools = state.get("allowed_tools")
         session = AgentSession(
             db, conversation, provider, REGISTRY, gate,
             state.get("params", {}), state["profile"], state.get("model"),
+            allowed_tools=set(allowed_tools) if allowed_tools is not None else None,
         )
         # Consume the pending row before resuming (it's superseded once we continue).
         db.delete(pending)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -63,6 +63,8 @@ class ChatRequest(BaseModel):
     model: str | None = None
     # When true, tools whose policy is "ask" are auto-approved for this turn.
     auto_approve: bool = True
+    # When true, advertise web_search to the model for this turn.
+    web_search: bool = False
     # When true, re-run the existing history without appending a new user message
     # (used by "regenerate" after the last assistant turn was deleted).
     regenerate: bool = False

--- a/backend/config.yml.example
+++ b/backend/config.yml.example
@@ -149,6 +149,11 @@ resilience:
   max_retries: 2               # SDK-level retries on transient errors (429/5xx/timeouts)
   fallback_profile: null       # e.g. "local-ollama" — used if the active provider errors
 
+# Live web search. By default `web_search` uses ddgs, which needs no API key or signup.
+# Optional: point at a SearXNG instance with JSON output enabled.
+web_search:
+  searxng_url: ""              # e.g. http://localhost:8080 (or set SEARXNG_URL)
+
 # Code/shell execution sandbox.
 #   runner: local      -> run on the host (fast, trusts the host; fine for single-user/dev)
 #   runner: container  -> run in an ephemeral, resource-limited container per execution.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "qdrant-client>=1.12.0",
     "bcrypt>=4.2.0",
     "pyjwt>=2.10.0",
+    "ddgs>=9.14.4",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -59,7 +59,34 @@ def test_tools_list_admin(client):
     r = client.get("/api/tools")
     assert r.status_code == 200
     names = [t["name"] for t in r.json()]
-    assert "write_file" in names and "execute_python" in names
+    assert "write_file" in names and "execute_python" in names and "web_search" in names
+
+
+def test_chat_web_search_advertised_only_when_requested(client, monkeypatch):
+    from app.providers.base import StreamDelta
+    import app.routers.chat as chat_router
+
+    seen_tools = []
+
+    class CaptureProvider:
+        model = "capture"
+        supports_tools = True
+
+        def stream(self, messages, tools, params):  # noqa: ARG002
+            seen_tools.append({tool.name for tool in tools})
+            yield StreamDelta(type="text", text="ok")
+            yield StreamDelta(type="done", stop_reason="stop")
+
+    monkeypatch.setattr(chat_router, "build_provider", lambda profile, model=None: CaptureProvider())
+    monkeypatch.setattr(chat_router, "_build_fallback", lambda active_profile: None)
+
+    r = client.post("/api/chat", json={"message": "hello"})
+    assert r.status_code == 200
+    assert seen_tools and "web_search" not in seen_tools[-1]
+
+    r = client.post("/api/chat", json={"message": "hello", "web_search": True})
+    assert r.status_code == 200
+    assert "web_search" in seen_tools[-1]
 
 
 def test_usage_summary(client):

--- a/backend/tests/test_harness.py
+++ b/backend/tests/test_harness.py
@@ -32,7 +32,7 @@ class FailingProvider:
 
     def stream(self, messages, tools, params):
         raise RuntimeError("primary down")
-        yield  # noqa: unreachable — makes this a generator
+        yield  # pragma: no cover - makes this a generator
 
 
 class TextProvider:
@@ -42,6 +42,25 @@ class TextProvider:
     def stream(self, messages, tools, params):
         yield StreamDelta(type="text", text="Answer from the fallback model.")
         yield StreamDelta(type="done", stop_reason="stop")
+
+
+class UnexpectedToolProvider:
+    model = "unexpected"
+    supports_tools = True
+
+    def __init__(self):
+        self.round = 0
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        self.round += 1
+        if self.round == 1:
+            yield StreamDelta(
+                type="tool_calls",
+                tool_calls=[ToolCall(id="c1", name="web_search", arguments={"query": "latest"})],
+            )
+        else:
+            yield StreamDelta(type="text", text="Done.")
+            yield StreamDelta(type="done", stop_reason="stop")
 
 
 def _new_conversation(db):
@@ -96,3 +115,13 @@ def test_fallback_provider_used_on_primary_failure(db):
     asst = [m for m in conv.messages if m.role == "assistant"]
     assert asst and "fallback model" in asst[-1].content.lower()
     assert "switching to fallback" in events.lower()
+
+
+def test_allowed_tools_denies_unadvertised_tool_calls(db):
+    conv = _new_conversation(db)
+    session = _session(db, conv, UnexpectedToolProvider(), allowed_tools=set())
+    events = "".join(session.run([{"role": "system", "content": "s"},
+                                  {"role": "user", "content": "search"}]))
+
+    assert "web_search" in events
+    assert "not enabled for this turn" in events

--- a/backend/tests/test_unit.py
+++ b/backend/tests/test_unit.py
@@ -99,6 +99,23 @@ def test_compute_cost_from_pricing(monkeypatch):
     assert observability.compute_cost("unknown", {"input": 100}) is None
 
 
+def test_web_search_normalizes_bounded_triplets():
+    from app.agent.tools.web import WebSearch
+
+    results = WebSearch()._normalize_results(
+        [
+            {"title": " Example  title ", "href": "https://example.com", "body": "snippet " * 120},
+            {"title": "No URL"},
+        ],
+        max_results=10,
+    )
+
+    assert len(results) == 1
+    assert results[0]["title"] == "Example title"
+    assert results[0]["url"] == "https://example.com"
+    assert results[0]["snippet"].endswith("... [truncated]")
+
+
 # -- bedrock auth modes ----------------------------------------------------
 def test_bedrock_auth_modes_select_signer():
     """The single Bedrock API key uses bearer auth; IAM creds and the default chain use

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -147,6 +147,79 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/53/6262c2256513e6f530d81642477cb19367270922063eaa2d7b781d8c723d/brotlicffi-1.2.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e015af99584c6db1490a69a210c765953e473e63adc2d891ac3062a737c9e851", size = 402265, upload-time = "2026-03-05T19:54:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d9/d5340b43cf5fbe7fe5a083d237e5338cc1caa73bea523be1c5e452c26290/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37cb587d32bf7168e2218c455e22e409ad1f3157c6c71945879a311f3e6b6abf", size = 406710, upload-time = "2026-03-05T19:54:07.272Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/dbced4c1e0792efdf23fd90ff6d2a320c64ff4dfef7aacc85c04fde9ddd2/brotlicffi-1.2.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d6ba65dd528892b4d9960beba2ae011a753620bcfc66cf6fa3cee18d7b0baa4", size = 402787, upload-time = "2026-03-05T19:54:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/6f/534205ba7590c9a8716a614f270c5c2ec419b5b7079b3f9cd31b7b5580de/brotlicffi-1.2.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2a5575653b0672638ba039b82fda56854934d7a6a24d4b8b5033f73ab43cbc1", size = 375108, upload-time = "2026-03-05T19:54:10.079Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
@@ -303,12 +376,37 @@ wheels = [
 ]
 
 [[package]]
+name = "ddgs"
+version = "9.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "fake-useragent" },
+    { name = "httpx", extra = ["brotli", "http2", "socks"] },
+    { name = "lxml" },
+    { name = "primp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/24/9d29eeb7dd4852c27c3673adcaf30c4dc55ced76b303c1fbb792ce7cae52/ddgs-9.14.4.tar.gz", hash = "sha256:f7b118a2b709a9e9c04a1dca6e96b98c25d4dfaca1a4b0a244d74454fcca48ef", size = 59742, upload-time = "2026-05-15T06:53:45.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/5f/32de4d99220eb559b7b1cd1c529a1856efa8097f7a3e10b6c207aa95e36c/ddgs-9.14.4-py3-none-any.whl", hash = "sha256:acb084c34bf1110c974caf7e5e5a2c1973beb4bd9e170bfd191fe5ed2d2b2d6c", size = 70638, upload-time = "2026-05-15T06:53:44.761Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
 ]
 
 [[package]]
@@ -544,8 +642,15 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+brotli = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+]
 http2 = [
     { name = "h2" },
+]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -556,60 +661,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
-
-[[package]]
-name = "phlox-backend"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "bcrypt" },
-    { name = "boto3" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "mcp" },
-    { name = "numpy" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt" },
-    { name = "pypdf" },
-    { name = "python-docx" },
-    { name = "python-multipart" },
-    { name = "pyyaml" },
-    { name = "qdrant-client" },
-    { name = "sqlalchemy" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "bcrypt", specifier = ">=4.2.0" },
-    { name = "boto3", specifier = ">=1.42.0" },
-    { name = "fastapi", specifier = ">=0.135.0" },
-    { name = "httpx", specifier = ">=0.28.0" },
-    { name = "mcp", specifier = ">=1.2.0" },
-    { name = "numpy", specifier = ">=2.1.0" },
-    { name = "openai", specifier = ">=2.26.0" },
-    { name = "pydantic", specifier = ">=2.10.0" },
-    { name = "pydantic-settings", specifier = ">=2.7.0" },
-    { name = "pyjwt", specifier = ">=2.10.0" },
-    { name = "pypdf", specifier = ">=5.1.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
-    { name = "python-docx", specifier = ">=1.1.2" },
-    { name = "python-multipart", specifier = ">=0.0.18" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "qdrant-client", specifier = ">=1.12.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.48" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "hyperframe"
@@ -999,6 +1050,62 @@ wheels = [
 ]
 
 [[package]]
+name = "phlox-backend"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "boto3" },
+    { name = "ddgs" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt" },
+    { name = "pypdf" },
+    { name = "python-docx" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bcrypt", specifier = ">=4.2.0" },
+    { name = "boto3", specifier = ">=1.42.0" },
+    { name = "ddgs", specifier = ">=9.14.4" },
+    { name = "fastapi", specifier = ">=0.135.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "mcp", specifier = ">=1.2.0" },
+    { name = "numpy", specifier = ">=2.1.0" },
+    { name = "openai", specifier = ">=2.26.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pyjwt", specifier = ">=2.10.0" },
+    { name = "pypdf", specifier = ">=5.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
+    { name = "python-docx", specifier = ">=1.1.2" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "qdrant-client", specifier = ">=1.12.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.48" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.41.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1017,6 +1124,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
+name = "primp"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/4b/7efa54f38da7de8df6b70dfed173bb41a52b740b144e4be24c1172db4209/primp-1.3.1.tar.gz", hash = "sha256:b04a5941bf9c876d011c5defaf5a25be093d56e7270b8da52c9788b9df2a829a", size = 1360029, upload-time = "2026-05-23T17:39:25.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/80/c4885a783a7493e396d89a592ba19fce63ef6bd6ad47230924a884a30ec0/primp-1.3.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:27b87e6370045a0c65c0e4dfdfacbfe637387d05673ce8ddcce400263f7c27f0", size = 5123967, upload-time = "2026-05-23T17:39:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/58/c1/c965cc23f96a364803d44b4331f33e4465bb6f269add37e39d0ad77ffe33/primp-1.3.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:27a8804eb9a3f641f379ee2b443591428cf85c898816e93d04d3e7b6f229ebcb", size = 4743059, upload-time = "2026-05-23T17:39:15.536Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/f4248d8d833d43fd8ba78208f2f4bf7fba7d3aec8c516090a95d18d6f550/primp-1.3.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862974796552a51af8e276bb19c5d5e189168ab8bad216aef7ce3726a8d3b1dd", size = 5100121, upload-time = "2026-05-23T17:39:04.64Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/519e32e0184763e1a76c9321fdeac0bb9b30bf85746f12058feec0cc4a27/primp-1.3.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ceb24198994799706f4020a00173ba9c1b491aa9805b1e014d87946677bc3c5d", size = 4738042, upload-time = "2026-05-23T17:39:35.967Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7b/723cb40694b47ec79a142ed8492835c0ecae9fef7acbed014f04b018d1de/primp-1.3.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3298b8afcf0a88ba6622bfc18e78aeb11afbb7d5afa4774f24acf7491f54a2d", size = 5001773, upload-time = "2026-05-23T17:39:03.01Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/80a2e3bdab1c51d738b82ea210a5ab93986b443c561e792e42cae296ec10/primp-1.3.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6b8d38c5a6d0a863274cbcae9678f265fcdcead3c20d12d152244e88f5f2186b", size = 5334228, upload-time = "2026-05-23T17:39:24.214Z" },
+    { url = "https://files.pythonhosted.org/packages/19/70/c95b8054c7d1fe2d84226ec60a5f48ce6c95a08b7c8b1702d7742082f444/primp-1.3.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f831c78ddb5900873f51e294bf9bbb4bbfdac3a2f39ce4023f8c558d299332", size = 5157269, upload-time = "2026-05-23T17:38:48.142Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bb/9b66986b7ecf2eff987134cd94bde533142e3085d6f67531f1a369ceaaae/primp-1.3.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329d0c320841f65b39d80801d8bae126732b84ec1094ca17b14fda0bda1b20ff", size = 5347438, upload-time = "2026-05-23T17:39:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/5d127748d06f3c6a3367f3c4974e45b98cda61cd28ea79ef91ad3fe9e093/primp-1.3.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6c3c67670c38a03e9e8da45b212243d35afc8efa018317c46ecdce47f05329d1", size = 5264862, upload-time = "2026-05-23T17:39:20.625Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f3/1aac229425cac142c48418e2de9f70597161ea936543b5e3c9e7476e1921/primp-1.3.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9409a31028a8c62a609d389554ad4f5339aad075130300cd443beef0336d7179", size = 4969889, upload-time = "2026-05-23T17:39:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/a94d6e6166139c76ae42eb941328679309ca85139e8753d639657a24474c/primp-1.3.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:88ca36c2bd1b7c64b96ad07ca367d2d111ac8e9670549be5f232da8bf795d21e", size = 5082679, upload-time = "2026-05-23T17:39:28.411Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/61/21d297db575ed660c6aaf35c9014c1874ace45d6dcb79d1a4d3d2608bffb/primp-1.3.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74d13800b501aa003fb05c263d38f8d61656c83a60b2951046c0fc412bc73976", size = 5605392, upload-time = "2026-05-23T17:39:38.007Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d6/9262a7ebb1d980a2db0cd505bb902bb3e66acd8a1cb763a4c2921f2f6a5b/primp-1.3.1-cp310-abi3-win32.whl", hash = "sha256:09ada1752629fe89d7b128beeb59cb641f404af462e24177ba36aed1cf322299", size = 4270373, upload-time = "2026-05-23T17:38:44.98Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/68/f0c6a60fadff0c185aef232b951a6fa4bbb64511facc48d34734db14f16f/primp-1.3.1-cp310-abi3-win_amd64.whl", hash = "sha256:c0d1e294466cd5ec7ef173eedf8df25cbdc050138d40447a906e92b8553e7765", size = 4661498, upload-time = "2026-05-23T17:39:32.213Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/232a52abc77384ac66b9c1741691dec3659b1207bb6c5e55c1e9b59d22f1/primp-1.3.1-cp310-abi3-win_arm64.whl", hash = "sha256:43304cb41cbb46f361de49faf1cbdba57f969f628c9297239c7ed8ef0cac420f", size = 4624481, upload-time = "2026-05-23T17:38:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/34333b26c533c3122b936dad829f0a6e04f32065d39673c92b157d97aa16/primp-1.3.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:72249a4540d0a8965f36eb9a86cd16801d1c7e8dac2f0b0fa23a0a5a03402d36", size = 5116098, upload-time = "2026-05-23T17:38:55.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/56/7fe14708adf9a5cb5d6a15ad840a3de036cebfaf20692a5bc3b72e188a73/primp-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:db4e2eaa5707e47899eeba6026f420f9b0108a28c08d63f1826d0cab8d50f06f", size = 4736300, upload-time = "2026-05-23T17:38:51.792Z" },
+    { url = "https://files.pythonhosted.org/packages/31/cb/521a8c18e8808a75450b6e91dc62cc1149c0178b7d4a8697d3f9b73fa385/primp-1.3.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d62e7609c98b4bc99c9cecc47f16f332fb8fe1a023002176267b0043dedad0c7", size = 5093823, upload-time = "2026-05-23T17:38:50.059Z" },
+    { url = "https://files.pythonhosted.org/packages/57/84/90f776fe46aeb0e3b86df72c674c0651326dd6a61846dd86bddbabe903ac/primp-1.3.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d692e912c2b25271163ba7719df0afdb733a7e7c3073c9094e9001882463543", size = 4734511, upload-time = "2026-05-23T17:39:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/d9bfbc0df0394f18a98b512a65f4bcf3dd7d17bd871937127e1ce4549172/primp-1.3.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c08693517dc160a12c0f9e2565c5319173cef738893a303ff2fb28ecccbd84d", size = 4999315, upload-time = "2026-05-23T17:39:12.061Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d8/5a986957ee1874d08567d7749668cd78a063048d47d6e46a874742b7fed1/primp-1.3.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d134ebfa31adc619e4e48289fe3e7eebc8310141560e6a6a04269cc94893d9ab", size = 5329375, upload-time = "2026-05-23T17:39:30.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/1d/321cac9902cc3992174ed530719141a0da2e426f54f8a90b7b971571d104/primp-1.3.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48e27e7c0e015a6de495cf79c0c8d599ba5f69d091af31572bec2de020522d9c", size = 5140921, upload-time = "2026-05-23T17:38:53.528Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/19/ccbe6b67e0e91beb5c9d5cf804354225d5a3a7a9adf84fee3d6acc53febd/primp-1.3.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c3d682df08c1b1f37b1f66b21fd173baebcfcb52490830b12292d8fe89b2147", size = 5344288, upload-time = "2026-05-23T17:39:18.965Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/a735751bd11558163e83e0961fc866e4f94634df9eb24937c5f59624e393/primp-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fabaac4280df0802377d34b869949d617a0ecf22ca7fd5f9bded3f5c981031f1", size = 5262909, upload-time = "2026-05-23T17:39:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8e/4e3d4520e2e751f2de825dbe2cb43f837d33a5528adc44255f9770ea125a/primp-1.3.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f510e5881e0a4c4b9e7dbc03722c316d58454388b88000a0e7bf18a4b36d601e", size = 4964809, upload-time = "2026-05-23T17:38:59.023Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/e7b7495687d07df693325a12c497a9e5185d5001b7b216f32019fa7437a0/primp-1.3.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0504de2901c97903a9c369856a4b186dc90a782d8320652c142b066e697d5a1a", size = 5083654, upload-time = "2026-05-23T17:39:06.598Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f9/e4652e93beb14a16cc4218cfb1ccc18eaca8ee7d93b517d614a135928ec9/primp-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c3b24e302d95d327e873834b9423823b9c8af2abf5e0bbf57a03f3354cfe528", size = 5594738, upload-time = "2026-05-23T17:39:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/49/e8c8a7bc6b741ab6f15896022eee4f906d04d7ccd15aeeb515dd04bbeb6d/primp-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:4346dcef805279028bf4a54bb87dd43d0920130e25b5790689f5c96c9ba0d9e5", size = 4262615, upload-time = "2026-05-23T17:39:13.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/84/7ae4a257dec6dff329d4a8d9051d907316095c27ffc8d1ea15c359e6eeb5/primp-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6c55f152a73b6d6af8ac37bdb648d8bbfd7e656f9ef40d87feb3c0d81cee930a", size = 4660584, upload-time = "2026-05-23T17:39:10.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/20/10e0d96bfaeef1f0cd339ccf9bb8feb4bf798fde93198f7a96c73441080a/primp-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:46a529d74583d6ceba52e15bf4c678fcf24e6d669c1ce935262d5490d1b25801", size = 4623226, upload-time = "2026-05-23T17:38:57.256Z" },
 ]
 
 [[package]]
@@ -1564,6 +1709,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]

--- a/docs/ADDING_A_TOOL.md
+++ b/docs/ADDING_A_TOOL.md
@@ -76,6 +76,12 @@ That's it. On next startup the tool is registered, a `ToolPref` row is seeded wi
 
 Mutating or executing tools should default to `ask`. Read-only tools can be `auto`.
 
+Some built-in tools also need per-turn user intent, not just a global tool preference.
+For those, keep the tool registered normally, but pass an `allowed_tools` set into
+`AgentSession` from `routers/chat.py` and omit the tool unless the request opts in. The
+`web_search` tool is the reference pattern: it appears in the Tool Manager, but the model
+only sees it when the Composer sends `web_search: true` for that prompt.
+
 ## 4. Test
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,6 +97,10 @@ deals with provider-specific shapes.
   default policy (`auto|ask|deny`); read-only tools are `auto`, mutating/exec tools are
   `ask`. "Agent mode" in the composer sets `auto_approve`, which promotes `ask`→`allow`
   for that turn. Users override per-tool in the Tool Manager (persisted in `ToolPref`).
+- **Live web search is opt-in per prompt.** `web_search` is registered like other tools,
+  but `routers/chat.py` passes an `allowed_tools` set to `AgentSession` and removes
+  `web_search` unless the composer request has `web_search: true`. The tool uses ddgs by
+  default and can use SearXNG via `web_search.searxng_url` / `SEARXNG_URL`.
 - **Sandbox is a swappable interface** (`sandbox/runner.py`). `LocalSubprocessRunner`
   (host, fast) and `ContainerRunner` (ephemeral Podman/Docker container with CPU/mem/PID
   limits + network isolation, workspace bind-mounted) are selected by `sandbox.runner` in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,6 +61,12 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
   to global + current-conversation docs via a Qdrant payload filter. _Implemented in:_
   `Document.conversation_id`, `rag/store.py` scope filter, `rag/retrieve.py`,
   `routers/documents.py`.
+- [x] **Opt-in live web search.** `web_search` discovers current web results with
+  zero-config ddgs by default, optional SearXNG via `web_search.searxng_url` /
+  `SEARXNG_URL`, and a per-prompt Composer toggle keeps the tool unadvertised unless the
+  user enables it for that turn. _Implemented in:_ `agent/tools/web.py`,
+  `routers/chat.py`, `agent/harness.py`, `schemas.py`, `Composer.jsx`, store
+  `sendMessage`.
 
 ## Tier 3 — Multi-user, isolation & operability
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "hutchchat-frontend",
+  "name": "phlox-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hutchchat-frontend",
+      "name": "phlox-frontend",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "katex": "^0.16.11",
         "lucide-react": "^0.456.0",
@@ -964,9 +965,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -981,9 +979,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -998,9 +993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1015,9 +1007,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1032,9 +1021,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1049,9 +1035,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1066,9 +1049,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,9 +1063,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1100,9 +1077,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1117,9 +1091,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,9 +1105,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,9 +1133,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/frontend/src/components/chat/Composer.jsx
+++ b/frontend/src/components/chat/Composer.jsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import { Send, Square, Paperclip, Zap, ImagePlus, X } from 'lucide-react'
+import { Send, Square, Paperclip, Zap, ImagePlus, X, Search } from 'lucide-react'
 import { useStore } from '../../store/useStore'
 import { api } from '../../api/client'
 import TokenMeter from './TokenMeter'
@@ -16,6 +16,7 @@ function fileToDataUrl(file) {
 export default function Composer() {
   const [text, setText] = useState('')
   const [autoApprove, setAutoApprove] = useState(true)
+  const [webSearch, setWebSearch] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [images, setImages] = useState([]) // data URLs
   const streaming = useStore((s) => s.streaming)
@@ -31,7 +32,7 @@ export default function Composer() {
   const submit = () => {
     if (!text.trim() && images.length === 0) return
     // While streaming, the store queues this as a follow-up (steering).
-    send(text.trim(), { autoApprove, images })
+    send(text.trim(), { autoApprove, webSearch, images })
     setText('')
     setImages([])
     if (taRef.current) taRef.current.style.height = 'auto'
@@ -143,12 +144,19 @@ export default function Composer() {
             </button>
           )}
         </div>
-        <div className="mt-1.5 flex items-center justify-between px-1 text-xs text-muted">
-          <label className="flex cursor-pointer items-center gap-1.5" title="Auto-approve tools that normally ask">
-            <input type="checkbox" checked={autoApprove} onChange={(e) => setAutoApprove(e.target.checked)}
-              className="rounded border-border text-accent focus:ring-accent" />
-            <Zap size={12} /> Agent mode (auto-run tools)
-          </label>
+        <div className="mt-1.5 flex items-center justify-between gap-3 px-1 text-xs text-muted">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+            <label className="flex cursor-pointer items-center gap-1.5" title="Auto-approve tools that normally ask">
+              <input type="checkbox" checked={autoApprove} onChange={(e) => setAutoApprove(e.target.checked)}
+                className="rounded border-border text-accent focus:ring-accent" />
+              <Zap size={12} /> Agent mode (auto-run tools)
+            </label>
+            <label className="flex cursor-pointer items-center gap-1.5" title="Allow live web search for this prompt">
+              <input type="checkbox" checked={webSearch} onChange={(e) => setWebSearch(e.target.checked)}
+                className="rounded border-border text-accent focus:ring-accent" />
+              <Search size={12} /> Web search
+            </label>
+          </div>
           <TokenMeter />
         </div>
       </div>

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -21,7 +21,7 @@ export const useStore = create((set, get) => ({
   live: null, // emptyLive() while streaming
   abortFn: null,
   error: null,
-  queued: null, // a follow-up message queued while streaming {text, images, autoApprove}
+  queued: null, // a follow-up message queued while streaming {text, images, autoApprove, webSearch}
   lastUsage: null, // {input, output, total} token usage from the last model response
 
   // -- auth ----------------------------------------------------------------
@@ -167,11 +167,11 @@ export const useStore = create((set, get) => ({
   },
 
   // -- sending a message ---------------------------------------------------
-  async sendMessage(text, { autoApprove = true, images = [] } = {}) {
+  async sendMessage(text, { autoApprove = true, webSearch = false, images = [] } = {}) {
     if (!text.trim() && images.length === 0) return
     // Steering: if a turn is in flight, queue this as a follow-up to send when it finishes.
     if (get().streaming) {
-      set({ queued: { text, images, autoApprove } })
+      set({ queued: { text, images, autoApprove, webSearch } })
       return
     }
     const userMsg = {
@@ -191,6 +191,7 @@ export const useStore = create((set, get) => ({
       conversation_id: get().activeId,
       message: text,
       auto_approve: autoApprove,
+      web_search: webSearch,
       images,
     }
 
@@ -315,7 +316,11 @@ export const useStore = create((set, get) => ({
     const q = get().queued
     if (q) {
       set({ queued: null })
-      get().sendMessage(q.text, { autoApprove: q.autoApprove, images: q.images })
+      get().sendMessage(q.text, {
+        autoApprove: q.autoApprove,
+        webSearch: q.webSearch,
+        images: q.images,
+      })
     }
   },
 


### PR DESCRIPTION
Closes #7.

## Summary

Adds an opt-in live web search capability for agent turns.

The new `web_search` tool uses `ddgs` by default, so it works out of the box with no API key or signup. Self-hosters can optionally configure SearXNG via `web_search.searxng_url` or `SEARXNG_URL`. The composer now includes a per-prompt “Web search” toggle, off by default; when disabled, `web_search` is not advertised to the model and unexpected calls are denied at execution time.

## Changes

- Add built-in `web_search` tool returning bounded title/url/snippet results.
- Add zero-config `ddgs` dependency and optional SearXNG backend.
- Add `web_search` request flag and composer toggle.
- Gate `web_search` per turn through `AgentSession.allowed_tools`.
- Preserve allowed tools across approval resume.
- Add tests for tool advertisement, execution-time denial, and result normalization.
- Update README, roadmap, architecture, tool guide, and config example docs.

## Validation

- `cd backend && uv run ruff check app tests`
- `cd backend && uv run pytest`
- `cd frontend && npm run build`
- `git diff --check`