### PR TITLE
Make settings panel wider and user-resizable (#9)

### DIFF
--- a/frontend/src/components/settings/SettingsDrawer.jsx
+++ b/frontend/src/components/settings/SettingsDrawer.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, BarChart3, SlidersHorizontal } from 'lucide-react'
 import ProviderSettings from './ProviderSettings'
 import ThemeSwitcher from './ThemeSwitcher'
@@ -28,9 +28,88 @@ const ADMIN_TABS = [
   { id: 'tools', label: 'Tools', icon: Wrench },
 ]
 
+// Width of the sliding settings drawer, in pixels. The drawer is wider by default
+// than the old fixed `max-w-2xl` (672px) and can be resized by dragging its left
+// edge; the chosen width is remembered across sessions.
+const WIDTH_STORAGE_KEY = 'phlox.settingsDrawerWidth'
+const DEFAULT_WIDTH = 820
+const MIN_WIDTH = 560
+const RESIZE_STEP = 32 // px moved per arrow-key press when the handle is focused
+
+// Keep the drawer usable on small viewports: never wider than the window (minus a
+// small gutter) and never below the minimum, with the minimum itself capped so the
+// drawer still fits on narrow screens.
+function clampWidth(width, viewport = window.innerWidth) {
+  const maxWidth = Math.max(MIN_WIDTH, viewport - 48)
+  const minWidth = Math.min(MIN_WIDTH, maxWidth)
+  return Math.min(Math.max(width, minWidth), maxWidth)
+}
+
+function loadInitialWidth() {
+  if (typeof window === 'undefined') return DEFAULT_WIDTH
+  const stored = Number.parseInt(window.localStorage.getItem(WIDTH_STORAGE_KEY), 10)
+  return clampWidth(Number.isFinite(stored) ? stored : DEFAULT_WIDTH)
+}
+
 export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
   const isAdmin = useStore((s) => s.user?.role === 'admin')
   const [tab, setTab] = useState(initialTab)
+  const [width, setWidth] = useState(loadInitialWidth)
+  const [resizing, setResizing] = useState(false)
+  const widthRef = useRef(width)
+  widthRef.current = width
+
+  // Persist the chosen width whenever it settles.
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(WIDTH_STORAGE_KEY, String(width))
+    } catch {
+      // Ignore storage failures (e.g. private mode); width still works for the session.
+    }
+  }, [width])
+
+  // Re-clamp if the window shrinks below the current drawer width.
+  useEffect(() => {
+    const onResize = () => setWidth((w) => clampWidth(w))
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  // Drag-to-resize from the left edge. The drawer is anchored to the right, so a
+  // smaller distance from the right edge means a wider panel.
+  const startResize = useCallback((e) => {
+    e.preventDefault()
+    setResizing(true)
+    const onMove = (ev) => {
+      const clientX = ev.touches ? ev.touches[0].clientX : ev.clientX
+      setWidth(clampWidth(window.innerWidth - clientX))
+    }
+    const onUp = () => {
+      setResizing(false)
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+      window.removeEventListener('touchmove', onMove)
+      window.removeEventListener('touchend', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    window.addEventListener('touchmove', onMove, { passive: false })
+    window.addEventListener('touchend', onUp)
+  }, [])
+
+  // Keyboard resize when the handle is focused; double-click resets to default.
+  const onHandleKeyDown = useCallback((e) => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      setWidth((w) => clampWidth(w + RESIZE_STEP))
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      setWidth((w) => clampWidth(w - RESIZE_STEP))
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      setWidth(clampWidth(DEFAULT_WIDTH))
+    }
+  }, [])
 
   const TabButton = ({ t }) => {
     const Icon = t.icon
@@ -48,7 +127,34 @@ export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end bg-black/40" onClick={onClose}>
-      <div className="flex h-full w-full max-w-2xl flex-col bg-bg shadow-2xl" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="relative flex h-full w-full flex-col bg-bg shadow-2xl"
+        style={{ maxWidth: `${width}px` }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Resize handle on the left edge of the drawer. */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize settings panel"
+          aria-valuenow={Math.round(width)}
+          aria-valuemin={MIN_WIDTH}
+          aria-valuemax={Math.round(clampWidth(window.innerWidth))}
+          tabIndex={0}
+          title="Drag to resize · double-click to reset"
+          onMouseDown={startResize}
+          onTouchStart={startResize}
+          onDoubleClick={() => setWidth(clampWidth(DEFAULT_WIDTH))}
+          onKeyDown={onHandleKeyDown}
+          className="group absolute left-0 top-0 z-10 flex h-full w-2 -translate-x-1/2 cursor-col-resize touch-none items-center justify-center outline-none"
+        >
+          <span
+            className={`h-full w-0.5 transition-colors ${
+              resizing ? 'bg-accent' : 'bg-transparent group-hover:bg-accent/60 group-focus-visible:bg-accent'
+            }`}
+          />
+        </div>
+
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
           <h2 className="text-lg font-semibold text-content">Settings</h2>
           <button onClick={onClose} className="rounded p-2 text-muted hover:bg-surface-3 hover:text-content">


### PR DESCRIPTION
## Summary

Fixes #9 — the settings panel was a fixed-width 672px (`max-w-2xl`) drawer, which left the content area cramped. Long values were truncated in the input fields (model IDs like `us.anthropic.claude-...`, the Bedrock key / IAM key fields showing `set — blank keeps i[t]`), and the two-column rows had very little breathing room.

This makes the drawer **wider by default** and **user-resizable**, with the chosen width remembered across sessions.

## Changes

- **Wider default** — the drawer now opens at **820px** instead of 672px, so existing forms get noticeably more room without any interaction.
- **Drag to resize** — a handle on the left edge of the drawer lets you drag it wider/narrower (mouse and touch).
- **Width is clamped** to `[560px, viewport − 48px]` so it never gets unusably narrow and always fits the window; it re-clamps automatically if the window is resized smaller.
- **Persistence** — the width is saved to `localStorage` (`phlox.settingsDrawerWidth`) and restored next time you open settings.
- **Accessible & keyboard-friendly** — the handle is a `role="separator"` with `aria-value*` attributes and is focusable: Arrow keys nudge the width, `Home` resets to default, and double-clicking the handle also resets.

Only `frontend/src/components/settings/SettingsDrawer.jsx` changed (+108 / −2). No backend or API changes; no new dependencies.

## Verification

- `npm run build` (the frontend CI check) passes.
- Verified in a headless browser against the production build:
  - Default width renders at 820px with roomy form fields.
  - Dragging the handle resizes the panel (e.g. 820 → 1070px) and writes the value to `localStorage`.
  - Reopening the drawer restores the persisted width (1070px).
  - Keyboard: ArrowRight narrowed by 32px; `Home` and double-click reset to 820px.
  - On a 700px-wide viewport the drawer clamps to 652px so it stays fully visible.

### Before
The panel was fixed at 672px and content was cramped (see #9 screenshot).

### After (default 820px)
Form fields span the full width with comfortable spacing; the panel can be dragged wider as needed.
