### PR TITLE
feat: OpenAI-compatible API gateway with per-user API keys (Phase 1, #5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ lifecycle. Then the focused guides:
 - [docs/ADDING_A_TOOL.md](docs/ADDING_A_TOOL.md)
 - [docs/ADDING_A_PROVIDER.md](docs/ADDING_A_PROVIDER.md)
 - [docs/AUTH.md](docs/AUTH.md) — auth, roles, multi-user isolation, Entra ID SSO
+- [docs/API_GATEWAY.md](docs/API_GATEWAY.md) — OpenAI-compatible API gateway: keys + `/v1/*`
 - [docs/SANDBOX.md](docs/SANDBOX.md) — local vs Podman/Docker code-exec sandbox
 - [docs/THEMING.md](docs/THEMING.md)
 - [docs/MCP.md](docs/MCP.md)
@@ -71,6 +72,7 @@ live in `backend/evals/run_evals.py` and are not part of CI.
 **Tiers 1–4 complete** (see [docs/ROADMAP.md](docs/ROADMAP.md)): streaming chat + resumable
 agent loop with approvals, RAG (hybrid Qdrant + rerank), cross-conversation memory,
 sub-agents, checkpoints, multimodal, auth/multi-user + Entra SSO, container sandbox,
-observability + usage/cost chargeback, and tests/CI. **Tier 5** (Postgres, PHI/data
+observability + usage/cost chargeback, an OpenAI-compatible **API gateway** (Phase 1:
+per-user keys + `/v1/chat/completions` & `/v1/models`), and tests/CI. **Tier 5** (Postgres, PHI/data
 governance) is deferred and gates any sensitive-data deployment. Extend along the documented
 seams above.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ models).
   automatically.
 - 🔀 **Any provider** — named profiles for Bedrock / OpenAI-compatible endpoints,
   switchable live, with a connection tester.
+- 🚪 **OpenAI-compatible API gateway** — mint per-user API keys and call Phlox from any
+  OpenAI SDK/tool (`POST /v1/chat/completions`, `GET /v1/models`); every call flows through
+  the same per-user/department cost accounting. See [docs/API_GATEWAY.md](docs/API_GATEWAY.md).
 - 🏠 **Runs fully local** — point at **Ollama**, **LM Studio**, or **vLLM** (any
   OpenAI-compatible server) for offline, self-hosted inference with no cloud API key; RAG
   embeddings can run locally too.
@@ -67,6 +70,7 @@ models).
 | [docs/AUTH.md](docs/AUTH.md) | Local accounts, roles, multi-user isolation, **Entra ID SSO** setup |
 | [docs/SANDBOX.md](docs/SANDBOX.md) | Local vs **Podman/Docker container** code-execution sandbox |
 | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) | Token usage/cost, structured logs, OpenTelemetry tracing |
+| [docs/API_GATEWAY.md](docs/API_GATEWAY.md) | OpenAI-compatible API gateway: API keys + `/v1/*` endpoints |
 | [docs/MCP.md](docs/MCP.md) | Connecting MCP servers |
 | [docs/THEMING.md](docs/THEMING.md) | The theme token system + adding themes |
 | [docs/ADDING_A_TOOL.md](docs/ADDING_A_TOOL.md) · [docs/ADDING_A_PROVIDER.md](docs/ADDING_A_PROVIDER.md) | Extension guides |

--- a/backend/app/api_keys.py
+++ b/backend/app/api_keys.py
@@ -1,0 +1,111 @@
+"""API key generation, hashing, and lookup for the OpenAI-compatible gateway.
+
+A Phlox API key looks like ``phlox-sk-<43 url-safe base64 chars>``. Only its **SHA-256
+hash** is persisted (``ApiKey.key_hash``); the plaintext is returned to the caller exactly
+once at creation and is unrecoverable afterwards. Resolving a presented key is a single
+indexed hash lookup, so there is no per-request bcrypt cost on the hot gateway path (these
+are high-entropy random secrets, not user-chosen passwords, so a fast hash is appropriate).
+
+The owning ``user_id`` is the **billable identity**: gateway usage is attributed to that
+user (and, via the ledger's write-time snapshot, their department) exactly like interactive
+chat usage.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models import ApiKey
+
+# Human-recognizable, OpenAI-style prefix so keys are easy to spot in logs/config.
+KEY_PREFIX = "phlox-sk-"
+# Number of leading characters (incl. the prefix) kept as a non-secret display label.
+DISPLAY_PREFIX_LEN = len(KEY_PREFIX) + 4
+
+
+def hash_key(plaintext: str) -> str:
+    """Return the hex SHA-256 of a key. Used both at creation and on every lookup."""
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+
+
+def generate_key() -> tuple[str, str, str]:
+    """Mint a new key. Returns ``(plaintext, key_hash, display_prefix)``.
+
+    ``plaintext`` is shown to the user once; only ``key_hash`` is stored.
+    """
+    secret = f"{KEY_PREFIX}{secrets.token_urlsafe(32)}"
+    return secret, hash_key(secret), secret[:DISPLAY_PREFIX_LEN]
+
+
+def create_key(
+    db: Session,
+    *,
+    user_id: str,
+    name: str | None = None,
+    expires_at: datetime | None = None,
+    scopes: list[str] | None = None,
+) -> tuple[ApiKey, str]:
+    """Create and persist a key for ``user_id``; return ``(row, plaintext_secret)``.
+
+    The plaintext is the caller's only chance to see the full key.
+    """
+    plaintext, key_hash, prefix = generate_key()
+    row = ApiKey(
+        user_id=user_id,
+        name=(name or "API key").strip()[:150] or "API key",
+        key_hash=key_hash,
+        prefix=prefix,
+        scopes=scopes or None,
+        expires_at=expires_at,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row, plaintext
+
+
+def resolve_key(db: Session, plaintext: str) -> ApiKey | None:
+    """Resolve a presented key to its active, unexpired ``ApiKey`` row, or None.
+
+    Updates ``last_used_at`` (best-effort) on a successful resolve so the UI can show
+    recency. An inactive (revoked) or expired key resolves to None.
+    """
+    if not plaintext:
+        return None
+    row = db.query(ApiKey).filter(ApiKey.key_hash == hash_key(plaintext)).first()
+    if row is None or not row.is_active:
+        return None
+    if row.expires_at is not None:
+        exp = row.expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+        if exp <= datetime.now(timezone.utc):
+            return None
+    row.last_used_at = datetime.now(timezone.utc)
+    try:
+        db.commit()
+    except Exception:  # noqa: BLE001 — last_used_at is non-critical; never fail a request on it.
+        db.rollback()
+    return row
+
+
+def list_keys(db: Session, user_id: str) -> list[ApiKey]:
+    return (
+        db.query(ApiKey)
+        .filter(ApiKey.user_id == user_id)
+        .order_by(ApiKey.created_at.desc())
+        .all()
+    )
+
+
+def revoke_key(db: Session, user_id: str, key_id: str) -> bool:
+    """Soft-revoke a key the user owns (keeps the audit row). Returns True if revoked."""
+    row = db.get(ApiKey, key_id)
+    if row is None or row.user_id != user_id:
+        return False
+    row.is_active = False
+    db.commit()
+    return True

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -46,3 +46,33 @@ def require_admin(user: User = Depends(get_current_user)) -> User:
     if user.role != "admin":
         raise HTTPException(403, "Admin privileges required")
     return user
+
+
+def require_api_key(
+    authorization: str | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> User:
+    """Resolve an ``Authorization: Bearer <phlox-sk-...>`` API key to its owning user.
+
+    This is the auth seam for the OpenAI-compatible **gateway** (``/v1/*``). It deliberately
+    accepts *only* API keys (not the browser session JWT) so programmatic access is always
+    attributable to a named, revocable key. Errors mirror the OpenAI spec shape
+    (401 + ``error`` object) so SDKs surface them cleanly.
+
+    When ``auth.enabled`` is false the app is single-user dev mode: a valid key is still
+    required (so the gateway behaves identically in dev and prod), but it resolves against
+    the synthetic local admin when the stored key has no live ``User`` row.
+    """
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(401, "Missing API key. Pass 'Authorization: Bearer <key>'.")
+    from app.api_keys import resolve_key
+
+    key_row = resolve_key(db, authorization.split(" ", 1)[1].strip())
+    if key_row is None:
+        raise HTTPException(401, "Invalid, revoked, or expired API key.")
+    user = db.get(User, key_row.user_id)
+    if user is None and not get_auth_config()["enabled"]:
+        return _dev_admin()
+    if user is None or not user.is_active:
+        raise HTTPException(401, "The user for this API key is inactive or no longer exists.")
+    return user

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -71,9 +71,9 @@ def delete_user_data(db: Session, user_id: str) -> dict:
     import shutil
 
     from app.config import UPLOADS_DIR, WORKSPACES_DIR
-    from app.models import Conversation, Document, Memory, Setting
+    from app.models import ApiKey, Conversation, Document, Memory, Setting
 
-    counts = {"conversations": 0, "documents": 0, "memories": 0}
+    counts = {"conversations": 0, "documents": 0, "memories": 0, "api_keys": 0}
 
     for conv in db.query(Conversation).filter(Conversation.user_id == user_id).all():
         ws = WORKSPACES_DIR / conv.id
@@ -97,6 +97,12 @@ def delete_user_data(db: Session, user_id: str) -> dict:
     for mem in db.query(Memory).filter(Memory.user_id == user_id).all():
         db.delete(mem)
         counts["memories"] += 1
+
+    # Gateway API keys: hard-delete so a departing user's keys can never authenticate again.
+    # (The usage they already incurred lives on in the ledger, identity snapshotted.)
+    for k in db.query(ApiKey).filter(ApiKey.user_id == user_id).all():
+        db.delete(k)
+        counts["api_keys"] += 1
 
     # Per-user settings are keyed "<user_id>:<key>".
     for s in db.query(Setting).filter(Setting.key.like(f"{user_id}:%")).all():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.database import SessionLocal, init_db
 from app.observability import setup_observability
 from app.routers import (
     admin_config,
+    api_keys,
     attachments,
     auth,
     chat,
@@ -33,6 +34,7 @@ from app.routers import (
     conversations,
     documents,
     files,
+    gateway,
     mcp,
     memories,
     providers,
@@ -117,7 +119,7 @@ app.add_middleware(
 )
 
 for r in (auth, chat, conversations, providers, settings, documents, mcp, tools, files,
-          memories, checkpoints, attachments, usage, admin_config):
+          memories, checkpoints, attachments, usage, admin_config, api_keys, gateway):
     app.include_router(r.router)
 
 # Structured request logging (always) + OpenTelemetry tracing (if configured).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,6 +10,7 @@ Tables
 - ``Setting``       : key/value runtime settings (active profile, params, theme...).
 - ``McpServer``     : configured MCP servers to connect on demand.
 - ``ToolPref``      : per-tool enabled flag + permission policy.
+- ``ApiKey``        : hashed API key -> user identity, for the OpenAI-compatible gateway.
 - ``AppConfig``     : admin-edited overrides for deployment config (seeded from config.yml).
 """
 from __future__ import annotations
@@ -222,6 +223,43 @@ class UsageLedger(Base):
     total_tokens: Mapped[int] = mapped_column(Integer, default=0)
     cost_usd: Mapped[float | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_now, index=True)
+
+
+class ApiKey(Base):
+    """A user-issued API key for programmatic access to the OpenAI-compatible gateway
+    (``/v1/chat/completions``, ``/v1/models``).
+
+    **Only a hash of the key is stored** (``key_hash``), never the plaintext: the secret is
+    shown exactly once at creation time and is unrecoverable afterwards. A short, non-secret
+    ``prefix`` (e.g. ``phlox-sk-AbC1``) is kept so the UI can label each key and the bearer
+    middleware can scope its hash lookup. Bearer auth resolves a presented key to its
+    ``user_id`` (the billable identity), so all gateway usage attributes to the owning user
+    and their department in the chargeback ledger — identical to interactive chat usage.
+
+    Keys can be ``revoked`` (soft delete, keeps the audit row) or given an ``expires_at``.
+    ``scopes`` is reserved for future per-key capability limits (e.g. chat-only); it defaults
+    to the full gateway and is not yet enforced.
+    """
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
+    # Owner (billable identity). FK-free for parity with the rest of the per-user model;
+    # delete_user_data revokes/removes a departing user's keys.
+    user_id: Mapped[str] = mapped_column(String(32), index=True)
+    # Optional cost-center snapshot is NOT stored here; the ledger snapshots identity at
+    # write time from the live User, so a department change is reflected automatically.
+    name: Mapped[str] = mapped_column(String(150), default="API key")
+    # SHA-256 hex of the full secret. Unique so a presented key maps to at most one row.
+    key_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    # Non-secret display prefix ("phlox-sk-AbC1"), safe to show in the UI.
+    prefix: Mapped[str] = mapped_column(String(32))
+    # Reserved for future per-key capability scoping; full access when null/empty.
+    scopes: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
 
 
 class PendingApproval(Base):

--- a/backend/app/providers/registry.py
+++ b/backend/app/providers/registry.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from app.config import get_embeddings_config, get_profile, get_profiles
+from app.config import (
+    get_default_profile_name,
+    get_embeddings_config,
+    get_profile,
+    get_profiles,
+)
 from app.providers.base import LLMProvider
 from app.providers.bedrock_provider import BedrockProvider
 from app.providers.openai_provider import OpenAIProvider
@@ -69,6 +74,53 @@ def list_models(profile_name: str) -> list[str]:
         except Exception as e:  # noqa: BLE001
             logger.warning("Could not list models for %s: %s", profile_name, e)
     return [cfg["model"]] if cfg.get("model") else []
+
+
+def gateway_models() -> list[dict[str, Any]]:
+    """Flat list of callable models across all profiles, for the gateway ``GET /v1/models``.
+
+    Each entry advertises both a bare ``model`` id and a fully-qualified ``profile/model``
+    id (returned as the OpenAI ``id``), since the same model id (e.g. ``gpt-4o``) can exist
+    under several profiles. Clients may call either form; ``resolve_model`` disambiguates.
+    """
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for name, cfg in get_profiles().items():
+        models = list(cfg.get("models") or ([cfg["model"]] if cfg.get("model") else []))
+        for m in models:
+            qualified = f"{name}/{m}"
+            if qualified in seen:
+                continue
+            seen.add(qualified)
+            out.append({"id": qualified, "profile": name, "model": m})
+    return out
+
+
+def resolve_model(model: str) -> tuple[str, str]:
+    """Resolve a gateway ``model`` string to a concrete ``(profile, model)`` pair.
+
+    Accepts either ``"profile/model"`` (explicit) or a bare ``"model"`` (resolved against
+    the profile catalog; falls back to the default profile so a bare id always works for the
+    common single-profile deployment). Raises ``ValueError`` if it can't be resolved.
+    """
+    if not model:
+        raise ValueError("A 'model' is required.")
+    profiles = get_profiles()
+    # Explicit "profile/model" form.
+    if "/" in model:
+        profile, _, bare = model.partition("/")
+        if profile in profiles:
+            return profile, bare
+    # Bare model id: first profile that lists it (or whose single model matches).
+    for name, cfg in profiles.items():
+        catalog = cfg.get("models") or ([cfg["model"]] if cfg.get("model") else [])
+        if model in catalog:
+            return name, model
+    # Last resort: hand the bare id to the default profile (overrides its configured model).
+    default = get_default_profile_name()
+    if default:
+        return default, model
+    raise ValueError(f"Unknown model: {model!r}")
 
 
 def build_embedder() -> tuple[LLMProvider | None, str | None]:

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -1,0 +1,83 @@
+"""API key management for the OpenAI-compatible gateway.
+
+    GET    /api/api-keys        — list the signed-in user's keys (metadata only, no secrets)
+    POST   /api/api-keys        — mint a new key; the plaintext secret is returned **once**
+    DELETE /api/api-keys/{id}   — revoke a key the user owns
+
+Keys are per-user and scoped to their owner: a user manages only their own keys (admins
+included — there is no cross-user read, consistent with the privacy model in docs/AUTH.md).
+The full secret is shown exactly once at creation and is never recoverable afterwards.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app import api_keys as svc
+from app.auth.deps import get_current_user
+from app.database import get_db
+from app.models import User
+
+router = APIRouter(prefix="/api/api-keys", tags=["api-keys"])
+
+
+class ApiKeyOut(BaseModel):
+    id: str
+    name: str
+    prefix: str
+    is_active: bool
+    expires_at: datetime | None = None
+    last_used_at: datetime | None = None
+    created_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class CreateApiKeyIn(BaseModel):
+    name: str | None = None
+    expires_at: datetime | None = None
+
+
+class CreateApiKeyOut(ApiKeyOut):
+    # The plaintext secret — returned ONLY here, at creation, and never again.
+    key: str
+
+
+@router.get("", response_model=list[ApiKeyOut])
+def list_api_keys(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    return svc.list_keys(db, user.id)
+
+
+@router.post("", response_model=CreateApiKeyOut)
+def create_api_key(
+    body: CreateApiKeyIn,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    row, plaintext = svc.create_key(
+        db, user_id=user.id, name=body.name, expires_at=body.expires_at
+    )
+    return CreateApiKeyOut(
+        id=row.id,
+        name=row.name,
+        prefix=row.prefix,
+        is_active=row.is_active,
+        expires_at=row.expires_at,
+        last_used_at=row.last_used_at,
+        created_at=row.created_at,
+        key=plaintext,
+    )
+
+
+@router.delete("/{key_id}")
+def revoke_api_key(
+    key_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    # 404 (not 403) on a key the user doesn't own, so existence isn't leaked (per AUTH.md).
+    if not svc.revoke_key(db, user.id, key_id):
+        raise HTTPException(404, "API key not found")
+    return {"revoked": key_id}

--- a/backend/app/routers/gateway.py
+++ b/backend/app/routers/gateway.py
@@ -1,0 +1,217 @@
+"""OpenAI-compatible gateway: turn Phlox into an authenticated LLM endpoint.
+
+Phase 1 (raw passthrough) of issue #5: exactly one model call per request, so cost is
+predictable and existing OpenAI SDKs/tools work unmodified against ``<phlox>/v1``.
+
+    POST /v1/chat/completions   — streaming (SSE) or buffered, OpenAI request/response shape
+    GET  /v1/models             — the catalog of callable models across all profiles
+
+Auth is an API key (``Authorization: Bearer phlox-sk-...``) resolved to the owning user by
+:func:`app.auth.deps.require_api_key`. Usage is captured at the **model-call layer** and
+written to the same durable :class:`~app.models.UsageLedger` as interactive chat, so the
+admin chargeback view ("usage by month × user × department × model") already includes
+gateway traffic with no extra work. Tools/RAG/agentic behavior are intentionally **not**
+exposed here — that is Phase 2's ``/v1/agent/completions``.
+
+The handler is provider-agnostic: it reuses ``build_provider`` and the canonical
+``StreamDelta`` interface, so OpenAI-compatible backends, Bedrock, and local models all work.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Iterator
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.auth.deps import require_api_key
+from app.database import get_db
+from app.models import User
+from app.observability import compute_cost
+from app.providers.registry import build_provider, gateway_models, resolve_model
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/v1", tags=["gateway"])
+
+
+# --- Request schema (OpenAI-compatible subset) -------------------------------
+class ChatMessage(BaseModel):
+    role: str
+    content: str | None = None
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[ChatMessage]
+    temperature: float | None = None
+    max_tokens: int | None = None
+    stream: bool = False
+    # Accepted and ignored for compatibility (Phase 1 is single-call passthrough).
+    top_p: float | None = None
+    stop: list[str] | str | None = None
+    user: str | None = None
+
+
+def _err(status: int, message: str, etype: str = "invalid_request_error") -> JSONResponse:
+    """OpenAI-style error envelope so client SDKs parse failures cleanly."""
+    return JSONResponse(status_code=status, content={"error": {"message": message, "type": etype}})
+
+
+def _canonical(messages: list[ChatMessage]) -> list[dict]:
+    return [{"role": m.role, "content": m.content or ""} for m in messages]
+
+
+def _record(db: Session, *, request_id: str, user_id: str, model: str, usage: dict) -> None:
+    """Best-effort per-call ledger write (never breaks the API response)."""
+    if not usage.get("total"):
+        return
+    usage = dict(usage)
+    usage["cost"] = compute_cost(model, usage)
+    try:
+        from app.usage_ledger import record_gateway_usage
+
+        record_gateway_usage(
+            db, request_id=request_id, user_id=user_id, model=model, usage=usage
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception("Gateway usage ledger write failed (continuing)")
+
+
+@router.get("/models")
+def list_v1_models(_user: User = Depends(require_api_key)):
+    """OpenAI-compatible model list. ``id`` is the fully-qualified ``profile/model``."""
+    created = int(time.time())
+    return {
+        "object": "list",
+        "data": [
+            {"id": m["id"], "object": "model", "created": created, "owned_by": m["profile"]}
+            for m in gateway_models()
+        ],
+    }
+
+
+@router.post("/chat/completions")
+def chat_completions(
+    req: ChatCompletionRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_api_key),
+):
+    if not req.messages:
+        return _err(400, "'messages' must not be empty.")
+    try:
+        profile, model = resolve_model(req.model)
+    except ValueError as e:
+        return _err(404, str(e), etype="model_not_found")
+    try:
+        provider = build_provider(profile, model)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Gateway provider build failed")
+        return _err(502, f"Provider error: {e}", etype="api_error")
+
+    messages = _canonical(req.messages)
+    params = {
+        "temperature": req.temperature if req.temperature is not None else 0.3,
+        "max_tokens": req.max_tokens or 4096,
+    }
+    request_id = f"chatcmpl-{uuid.uuid4().hex}"
+    created = int(time.time())
+    # The id clients see uses the model string they sent; ledger uses our resolved model.
+    advertised_model = req.model
+
+    if req.stream:
+        return StreamingResponse(
+            _stream(db, provider, messages, params, request_id, created, advertised_model, user.id),
+            media_type="text/event-stream",
+        )
+    return _buffered(db, provider, messages, params, request_id, created, advertised_model, user.id)
+
+
+def _buffered(
+    db, provider, messages, params, request_id, created, advertised_model, user_id
+) -> JSONResponse:
+    """Run one non-streaming model call and return a full OpenAI ``chat.completion``."""
+    text = ""
+    usage = {"input": 0, "output": 0, "total": 0}
+    finish_reason = "stop"
+    try:
+        for delta in provider.stream(messages, [], params):
+            if delta.type == "text":
+                text += delta.text or ""
+            elif delta.type == "usage":
+                usage = delta.usage or usage
+            elif delta.type == "done":
+                finish_reason = _finish(delta.stop_reason)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Gateway model call failed")
+        return _err(502, f"Upstream model error: {e}", etype="api_error")
+
+    _record(db, request_id=request_id, user_id=user_id, model=provider.model, usage=usage)
+    return JSONResponse(
+        content={
+            "id": request_id,
+            "object": "chat.completion",
+            "created": created,
+            "model": advertised_model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": usage.get("input", 0),
+                "completion_tokens": usage.get("output", 0),
+                "total_tokens": usage.get("total", 0),
+            },
+        }
+    )
+
+
+def _stream(
+    db, provider, messages, params, request_id, created, advertised_model, user_id
+) -> Iterator[str]:
+    """Emit OpenAI-compatible ``chat.completion.chunk`` SSE frames for one model call."""
+    base = {"id": request_id, "object": "chat.completion.chunk", "created": created,
+            "model": advertised_model}
+
+    def frame(delta: dict, finish_reason=None) -> str:
+        payload = {**base, "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}]}
+        return f"data: {json.dumps(payload)}\n\n"
+
+    # First chunk carries the assistant role, per the OpenAI streaming contract.
+    yield frame({"role": "assistant"})
+    usage = {"input": 0, "output": 0, "total": 0}
+    finish_reason = "stop"
+    try:
+        for delta in provider.stream(messages, [], params):
+            if delta.type == "text" and delta.text:
+                yield frame({"content": delta.text})
+            elif delta.type == "usage":
+                usage = delta.usage or usage
+            elif delta.type == "done":
+                finish_reason = _finish(delta.stop_reason)
+    except Exception as e:  # noqa: BLE001
+        logger.exception("Gateway streaming model call failed")
+        # Surface a terminal error frame, then close the stream.
+        yield f"data: {json.dumps({'error': {'message': str(e), 'type': 'api_error'}})}\n\n"
+        yield "data: [DONE]\n\n"
+        return
+
+    yield frame({}, finish_reason=finish_reason)
+    yield "data: [DONE]\n\n"
+    _record(db, request_id=request_id, user_id=user_id, model=provider.model, usage=usage)
+
+
+def _finish(stop_reason: str | None) -> str:
+    """Map provider stop reasons to OpenAI ``finish_reason`` values."""
+    if stop_reason in ("length", "max_tokens"):
+        return "length"
+    if stop_reason == "tool_calls":
+        return "tool_calls"
+    return "stop"

--- a/backend/app/usage_ledger.py
+++ b/backend/app/usage_ledger.py
@@ -68,6 +68,45 @@ def record_usage(
     db.commit()
 
 
+def record_gateway_usage(
+    db: Session,
+    *,
+    request_id: str,
+    user_id: str | None,
+    model: str | None,
+    usage: dict,
+    parent_request_id: str | None = None,
+) -> None:
+    """Append one ledger row for a single **gateway** model call (``/v1/*`` API).
+
+    Captures usage at the *model-call layer*, so attribution is identical to interactive
+    chat: one row per model call, billed to the API key's owning user/department. The
+    synthetic ``request_id`` is stored in the ledger's unique ``message_id`` column so a
+    retried write can't double-count, and the (optional) ``parent_request_id`` is stored in
+    ``conversation_id`` to group the N model calls of one agentic request (Phase 2) for
+    accurate per-request totals. Best-effort: a ledger failure must never break the API
+    response, so callers should not let exceptions propagate.
+    """
+    if db.query(UsageLedger).filter(UsageLedger.message_id == request_id).first():
+        return
+    ident = _identity_snapshot(db, user_id)
+    inp = int(usage.get("input", 0) or 0)
+    out = int(usage.get("output", 0) or 0)
+    row = UsageLedger(
+        message_id=request_id,
+        # Reuse conversation_id as the agentic-request grouping key (null for passthrough).
+        conversation_id=parent_request_id,
+        model=model,
+        input_tokens=inp,
+        output_tokens=out,
+        total_tokens=int(usage.get("total", inp + out) or (inp + out)),
+        cost_usd=usage.get("cost"),
+        **ident,
+    )
+    db.add(row)
+    db.commit()
+
+
 def backfill_usage_ledger(db: Session) -> int:
     """Create ledger rows for any historical ``Message.usage`` that predates the ledger.
 

--- a/backend/tests/test_gateway.py
+++ b/backend/tests/test_gateway.py
@@ -1,0 +1,164 @@
+"""Tests for the API-key gateway: key CRUD, bearer auth, and the OpenAI-compatible
+``/v1/chat/completions`` + ``/v1/models`` endpoints (auth disabled -> single dev admin).
+
+A scripted provider replaces ``build_provider`` so no network/model is needed; usage is
+asserted to land in the durable ledger keyed by the gateway request id.
+"""
+import json
+
+from app.providers.base import StreamDelta
+
+
+class GatewayScriptedProvider:
+    """Minimal provider: streams two text chunks + a usage delta + done."""
+
+    model = "test-model"
+    supports_tools = True
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        yield StreamDelta(type="text", text="Hello, ")
+        yield StreamDelta(type="text", text="world!")
+        yield StreamDelta(type="usage", usage={"input": 11, "output": 7, "total": 18})
+        yield StreamDelta(type="done", stop_reason="stop")
+
+
+def _patch_provider(monkeypatch):
+    import app.routers.gateway as gw
+
+    monkeypatch.setattr(gw, "build_provider", lambda profile, model: GatewayScriptedProvider())
+
+
+def _make_key(client, name="test key"):
+    r = client.post("/api/api-keys", json={"name": name})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# --- key CRUD ----------------------------------------------------------------
+def test_api_key_create_returns_secret_once_then_hidden(client):
+    created = _make_key(client, "my key")
+    assert created["key"].startswith("phlox-sk-")
+    assert created["name"] == "my key"
+    assert created["prefix"] == created["key"][: len(created["prefix"])]
+
+    # The secret is never returned again by the list endpoint.
+    listed = client.get("/api/api-keys").json()
+    row = next(k for k in listed if k["id"] == created["id"])
+    assert "key" not in row
+    assert row["is_active"] is True
+
+
+def test_api_key_revoke(client):
+    created = _make_key(client)
+    assert client.delete(f"/api/api-keys/{created['id']}").status_code == 200
+    row = next(k for k in client.get("/api/api-keys").json() if k["id"] == created["id"])
+    assert row["is_active"] is False
+    # Revoking a non-existent / unowned key is a 404 (no existence leak).
+    assert client.delete("/api/api-keys/does-not-exist").status_code == 404
+
+
+# --- bearer auth -------------------------------------------------------------
+def test_gateway_requires_api_key(client):
+    assert client.get("/v1/models").status_code == 401
+    assert client.post("/v1/chat/completions", json={"model": "m", "messages": []}).status_code == 401
+
+
+def test_gateway_rejects_revoked_key(client, monkeypatch):
+    _patch_provider(monkeypatch)
+    created = _make_key(client)
+    client.delete(f"/api/api-keys/{created['id']}")
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": f"Bearer {created['key']}"},
+    )
+    assert r.status_code == 401
+
+
+# --- /v1/models --------------------------------------------------------------
+def test_v1_models_lists_catalog(client):
+    created = _make_key(client)
+    r = client.get("/v1/models", headers={"Authorization": f"Bearer {created['key']}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["object"] == "list"
+    ids = [m["id"] for m in body["data"]]
+    assert "test/test-model" in ids
+
+
+# --- /v1/chat/completions ----------------------------------------------------
+def test_chat_completions_buffered_and_records_usage(client, monkeypatch, db):
+    from app.models import UsageLedger
+
+    _patch_provider(monkeypatch)
+    # Price the model so cost is computed and stored.
+    monkeypatch.setattr(
+        "app.routers.gateway.compute_cost", lambda model, usage: 0.000123
+    )
+    created = _make_key(client)
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": f"Bearer {created['key']}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["object"] == "chat.completion"
+    assert body["choices"][0]["message"]["content"] == "Hello, world!"
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert body["usage"]["total_tokens"] == 18
+
+    # A ledger row was written, keyed by the returned request id, billed to the dev admin.
+    row = db.query(UsageLedger).filter(UsageLedger.message_id == body["id"]).first()
+    assert row is not None
+    assert row.total_tokens == 18
+    assert row.cost_usd == 0.000123
+
+
+def test_chat_completions_streaming(client, monkeypatch):
+    _patch_provider(monkeypatch)
+    created = _make_key(client)
+    r = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": f"Bearer {created['key']}"},
+    )
+    assert r.status_code == 200
+    assert "text/event-stream" in r.headers["content-type"]
+    chunks = [
+        json.loads(line[len("data: "):])
+        for line in r.text.splitlines()
+        if line.startswith("data: ") and not line.endswith("[DONE]")
+    ]
+    assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+    content = "".join(c["choices"][0]["delta"].get("content", "") for c in chunks)
+    assert content == "Hello, world!"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert "data: [DONE]" in r.text
+
+
+def test_chat_completions_empty_messages(client, monkeypatch):
+    _patch_provider(monkeypatch)
+    created = _make_key(client)
+    r = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": []},
+        headers={"Authorization": f"Bearer {created['key']}"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"]["type"] == "invalid_request_error"
+
+
+def test_resolve_model_qualified_bare_and_default():
+    from app.providers.registry import resolve_model
+
+    # Explicit "profile/model".
+    assert resolve_model("test/test-model") == ("test", "test-model")
+    # Bare id present in a profile's catalog.
+    assert resolve_model("test-model") == ("test", "test-model")
+    # Unknown bare id falls back to the default profile (model overridden).
+    assert resolve_model("some-other-model") == ("test", "some-other-model")

--- a/docs/API_GATEWAY.md
+++ b/docs/API_GATEWAY.md
@@ -1,0 +1,108 @@
+# API Gateway (OpenAI-compatible)
+
+Phlox can be called programmatically as an **authenticated, OpenAI-compatible LLM gateway**:
+one endpoint, all your configured models (Bedrock + any OpenAI-compatible backend), with the
+same per-user / per-department cost accounting as the chat UI. Point any OpenAI SDK or tool
+at `<phlox>/v1` and it works unmodified.
+
+> **Status — Phase 1 (raw passthrough).** Implements `POST /v1/chat/completions` and
+> `GET /v1/models`: **exactly one model call per request**, so cost is predictable. The
+> agentic pipeline (`POST /v1/agent/completions`, RAG + tools + MCP, fan-out usage grouped
+> by `parent_request_id`) is **Phase 2** — the auth + accounting layer below is already
+> built to absorb it (see [ROADMAP.md](ROADMAP.md) and issue #5).
+
+## 1. API keys
+
+Every user mints their own keys in **Settings → API Keys** (or via the REST API below).
+
+- A key looks like `phlox-sk-<random>`. The **full secret is shown exactly once** at
+  creation and is **never recoverable** — only a SHA-256 **hash** is stored
+  (`ApiKey.key_hash`), plus a short non-secret `prefix` for display.
+- Keys can be **revoked** (soft-delete; the audit row remains) and given an **expiry**.
+- A key resolves to its **owning user**, which is the **billable identity**: all gateway
+  usage attributes to that user and their department, exactly like interactive chat.
+- Deleting a user **hard-deletes their keys** (they can never authenticate again), while the
+  usage they already incurred survives in the ledger (identity snapshotted) — consistent
+  with the chargeback rationale in [AUTH.md](AUTH.md).
+
+### Key management REST API (browser session / JWT auth)
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/api-keys` | List your keys (metadata only — never the secret). |
+| `POST /api/api-keys` | Create a key. Body: `{ "name": "...", "expires_at": "<ISO>"? }`. Response includes `key` (the plaintext) **once**. |
+| `DELETE /api/api-keys/{id}` | Revoke a key you own (404 if not yours — no existence leak). |
+
+## 2. Gateway endpoints (API-key auth)
+
+Authenticate with `Authorization: Bearer phlox-sk-...`. These accept **only** an API key
+(not the browser JWT), so programmatic traffic is always tied to a named, revocable key.
+Errors use the OpenAI error envelope (`{"error": {"message", "type"}}`).
+
+### `GET /v1/models`
+
+Lists every callable model across all profiles. Each `id` is fully-qualified
+`profile/model` (since the same model id can exist under multiple profiles); a bare model
+id also works and resolves against the catalog (falling back to the default profile).
+
+### `POST /v1/chat/completions`
+
+OpenAI-spec request/response. Supports streaming (`"stream": true`, SSE
+`chat.completion.chunk` frames terminated by `data: [DONE]`) and buffered responses.
+Honored fields: `model`, `messages`, `temperature`, `max_tokens`, `stream`. Other fields
+(`top_p`, `stop`, `user`, …) are accepted and ignored in Phase 1. **Tools/RAG/agentic
+behavior are intentionally not exposed here** — that's Phase 2's `/v1/agent/completions`.
+
+### Examples
+
+```bash
+# List models
+curl https://phlox.example.com/v1/models \
+  -H "Authorization: Bearer phlox-sk-..."
+
+# One completion
+curl https://phlox.example.com/v1/chat/completions \
+  -H "Authorization: Bearer phlox-sk-..." -H "Content-Type: application/json" \
+  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+```python
+from openai import OpenAI
+client = OpenAI(api_key="phlox-sk-...", base_url="https://phlox.example.com/v1")
+resp = client.chat.completions.create(
+    model="my-profile/gpt-4o",                       # or just "gpt-4o"
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(resp.choices[0].message.content)
+```
+
+## 3. Cost / token accounting
+
+Usage is captured at the **model-call layer**, not the endpoint, so attribution is identical
+to interactive chat and is ready to absorb Phase 2's multi-call agentic requests. Each
+gateway model call appends one row to the durable **`UsageLedger`**
+(`usage_ledger.record_gateway_usage`):
+
+- Cost is computed from the `model_pricing` table (`observability.pricing`, also live-editable
+  in **Settings → Configuration**) — see [OBSERVABILITY.md](OBSERVABILITY.md).
+- The synthetic per-call `request_id` is stored in the ledger's unique `message_id` column,
+  so a retried write can't double-count.
+- `parent_request_id` (stored in `conversation_id`) is reserved to group the N calls of one
+  agentic request in Phase 2.
+
+Gateway usage therefore appears automatically in the admin **Usage & Cost** view
+(`GET /api/usage/by-user`, "usage by month × user × department × model") and the per-user
+`GET /api/usage` meter — no extra wiring.
+
+## 4. Where it lives (code map)
+
+| Concern | File |
+|---|---|
+| `ApiKey` table | `backend/app/models.py` |
+| Key generate / hash / resolve / CRUD service | `backend/app/api_keys.py` |
+| Key management router | `backend/app/routers/api_keys.py` |
+| Bearer-key auth dependency (`require_api_key`) | `backend/app/auth/deps.py` |
+| Gateway router (`/v1/*`) | `backend/app/routers/gateway.py` |
+| Model id → `(profile, model)` resolution + catalog | `backend/app/providers/registry.py` |
+| Per-call ledger write | `backend/app/usage_ledger.py` |
+| Settings → API Keys UI | `frontend/src/components/settings/ApiKeysPanel.jsx` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,8 @@ deals with provider-specific shapes.
 | **RAG** | `rag/ingest.py`, `embed.py`, `retrieve.py`, `store.py` | Parse → chunk → embed → **Qdrant** vector search (`VectorStore` seam) |
 | **MCP** | `mcp/manager.py` | Connect MCP servers, proxy their tools into the registry |
 | **Observability** | `observability.py`, `usage_ledger.py`, `routers/usage.py` | Per-request logging, OTel seam, per-turn token/cost capture + durable chargeback ledger. See [OBSERVABILITY.md](OBSERVABILITY.md) |
-| **Routers** | `routers/*.py` | `auth, chat, conversations, providers, settings, documents, mcp, tools, files, memories, checkpoints, attachments, usage, admin_config` |
+| **API gateway** | `api_keys.py`, `routers/api_keys.py`, `routers/gateway.py` | Per-user API keys (SHA-256 hashed) + OpenAI-compatible `/v1/chat/completions` & `/v1/models`; usage flows through `usage_ledger`. See [API_GATEWAY.md](API_GATEWAY.md) |
+| **Routers** | `routers/*.py` | `auth, chat, conversations, providers, settings, documents, mcp, tools, files, memories, checkpoints, attachments, usage, admin_config, api_keys, gateway` |
 
 ### Key design decisions
 - **One unified tool surface.** Built-in tools, MCP tools, and `search_documents` all
@@ -181,6 +182,9 @@ streamed markdown with highlighted, copyable code.
 - `UsageLedger` — append-only, **FK-free** per-turn token/cost rows with a snapshot of the
   billable identity (username/email/department). Deliberately survives user deletion for
   chargeback; see [OBSERVABILITY.md](OBSERVABILITY.md) / [AUTH.md](AUTH.md).
+- `ApiKey` — per-user gateway keys: only a SHA-256 `key_hash` (unique) + non-secret
+  `prefix` are stored, with `is_active`/`expires_at`/`last_used_at`. Resolves to the owning
+  `User` (the billable identity); hard-deleted with the user. See [API_GATEWAY.md](API_GATEWAY.md).
 - `AppConfig` — admin overrides for deployment config (section key → JSON), seeded from
   `config.yml`; the overlay that powers the admin **Configuration** tab (see §6).
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -28,8 +28,11 @@ regardless of provider, so the rest of the app is auth-method-agnostic.
   tool enable/permissions, **deployment configuration** (see below), and **user
   management** — create users, **reset passwords**, set a **department** (for chargeback),
   enable/disable, and **delete accounts**. Deleting an account **purges all of that user's
-  data** (chats + workspaces, documents + files + vectors, memories, settings) via
-  `auth/service.delete_user_data` — the admin never reads the content, it is just removed.
+  data** (chats + workspaces, documents + files + vectors, memories, settings, **API
+  keys**) via `auth/service.delete_user_data` — the admin never reads the content, it is
+  just removed. (A deleted user's gateway keys are hard-deleted so they can never
+  authenticate again, while their incurred usage survives in the ledger; see
+  [API_GATEWAY.md](API_GATEWAY.md).)
 - **Admin deployment configuration** (`routers/admin_config.py`, **Settings → (Admin)
   Configuration**): admins edit a curated set of `config.yml` sections **live, without a
   restart** — provider profiles, model pricing, resilience, generation defaults, and sandbox

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -45,7 +45,11 @@ capturing tokens/cost/model **plus a snapshot of the billable identity**
 - is **backfilled** once at startup from any pre-existing `Message.usage` history
   (idempotent), so historical cost isn't lost when the feature ships;
 - snapshots **department per turn**, so reassigning a user mid-month bills each department
-  for the usage incurred while the user was assigned to it.
+  for the usage incurred while the user was assigned to it;
+- also captures **API-gateway** traffic: each `/v1/chat/completions` call writes a ledger
+  row via `usage_ledger.record_gateway_usage` (keyed on a unique `request_id`, so retries
+  can't double-count), so programmatic usage shows up in the same chargeback view as chat.
+  See [API_GATEWAY.md](API_GATEWAY.md).
 
 ## 2. Structured request logging
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -144,6 +144,18 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
 - [x] **Keyboard shortcuts.** New chat (Ctrl/Cmd+K), toggle sidebar (Ctrl/Cmd+\\), Esc to
   close. Command palette + voice in/out still TODO.
 
+## API gateway (OpenAI-compatible)
+
+Use Phlox programmatically as an authenticated LLM gateway, with the same per-user/department
+cost accounting as interactive chat. See [API_GATEWAY.md](API_GATEWAY.md).
+
+- [x] **Phase 1 — raw passthrough.** Per-user API keys (SHA-256 hashed, revocable, expiring),
+  OpenAI-compatible `POST /v1/chat/completions` (streaming + buffered) and `GET /v1/models`,
+  exactly one model call per request, usage recorded to the `UsageLedger`.
+- [ ] **Phase 2 — agentic endpoint.** `POST /v1/agent/completions` exposing RAG + tools + MCP;
+  the N model calls of one request grouped by `parent_request_id` (the ledger seam is already
+  in place). Per-key budgets / rate-limiting are a candidate follow-up here.
+
 ## Tier 5 — Sensitive-data deployment (PHI)
 
 Deferred until the app is used with real/sensitive data. **Gates any PHI use.**
@@ -159,8 +171,10 @@ Deferred until the app is used with real/sensitive data. **Gates any PHI use.**
 ### Status
 **Tiers 1, 2, 3, and 4 are complete.** Remaining Tier 4 nice-to-haves: full
 conversation-branch tree, HTML/React live artifact previews, command palette, voice.
+**API gateway Phase 1 is complete; Phase 2 (`/v1/agent/completions`) is next.**
 **Postgres and PHI/data-governance are Tier 5**, deferred until a sensitive-data
 deployment.
 
-See [AUTH.md](AUTH.md) (auth/SSO), [SANDBOX.md](SANDBOX.md) (container sandbox), and
-[OBSERVABILITY.md](OBSERVABILITY.md) (logging/usage/tracing).
+See [AUTH.md](AUTH.md) (auth/SSO), [SANDBOX.md](SANDBOX.md) (container sandbox),
+[OBSERVABILITY.md](OBSERVABILITY.md) (logging/usage/tracing), and
+[API_GATEWAY.md](API_GATEWAY.md) (OpenAI-compatible gateway).

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -87,6 +87,11 @@ export const api = {
     return req('GET', `/api/usage/by-user${q ? `?${q}` : ''}`)
   },
 
+  // api keys (gateway access)
+  listApiKeys: () => req('GET', '/api/api-keys'),
+  createApiKey: (body) => req('POST', '/api/api-keys', body || {}),
+  revokeApiKey: (id) => req('DELETE', `/api/api-keys/${id}`),
+
   // memories
   listMemories: () => req('GET', '/api/memories'),
   addMemory: (body) => req('POST', '/api/memories', body),

--- a/frontend/src/components/settings/ApiKeysPanel.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.jsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react'
+import { KeyRound, Trash2, Plus, Copy, Check, AlertTriangle } from 'lucide-react'
+import { api } from '../../api/client'
+
+// User-level panel: mint, view, and revoke API keys for the OpenAI-compatible gateway
+// (POST /v1/chat/completions, GET /v1/models). The full secret is shown exactly once.
+export default function ApiKeysPanel() {
+  const [keys, setKeys] = useState([])
+  const [name, setName] = useState('')
+  const [creating, setCreating] = useState(false)
+  // The just-created plaintext secret, shown once until dismissed.
+  const [revealed, setRevealed] = useState(null)
+  const [copied, setCopied] = useState(false)
+
+  const load = () => api.listApiKeys().then(setKeys).catch(() => setKeys([]))
+  useEffect(() => { load() }, [])
+
+  const create = async () => {
+    setCreating(true)
+    try {
+      const created = await api.createApiKey({ name: name.trim() || 'API key' })
+      setRevealed(created)
+      setName('')
+      load()
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const copy = async () => {
+    if (!revealed) return
+    try {
+      await navigator.clipboard.writeText(revealed.key)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard may be unavailable (e.g. non-HTTPS); the user can still select the text.
+    }
+  }
+
+  const fmtDate = (s) => (s ? new Date(s).toLocaleDateString() : '—')
+
+  return (
+    <div>
+      <h3 className="mb-1 text-sm font-semibold text-content">API keys</h3>
+      <p className="mb-4 text-xs text-muted">
+        Use Phlox as an OpenAI-compatible gateway. Point any OpenAI SDK at{' '}
+        <code className="rounded bg-surface-3 px-1">{`${window.location.origin}/v1`}</code>{' '}
+        with one of these keys as the API key. Usage is metered to your account just like
+        chat. Keep keys secret — anyone with a key can spend on your behalf.
+      </p>
+
+      <div className="mb-4 flex gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && !creating && create()}
+          placeholder="Name this key (e.g. 'CI pipeline', 'laptop')"
+          className="flex-1 rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent"
+        />
+        <button
+          onClick={create}
+          disabled={creating}
+          className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm text-accent-fg hover:opacity-90 disabled:opacity-50"
+        >
+          <Plus size={16} /> Create key
+        </button>
+      </div>
+
+      {revealed && (
+        <div className="mb-4 rounded-lg border border-hutch-gold/40 bg-hutch-gold/10 p-3">
+          <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold text-content">
+            <AlertTriangle size={14} className="text-hutch-gold" />
+            Copy your key now — it won’t be shown again.
+          </div>
+          <div className="flex items-center gap-2">
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded bg-surface px-2 py-1.5 text-xs text-content">
+              {revealed.key}
+            </code>
+            <button
+              onClick={copy}
+              className="flex items-center gap-1 rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-content hover:border-accent"
+            >
+              {copied ? <Check size={14} className="text-green-500" /> : <Copy size={14} />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+            <button
+              onClick={() => setRevealed(null)}
+              className="rounded-lg px-2 py-1.5 text-xs text-muted hover:text-content"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {keys.length === 0 && <p className="text-sm text-muted">No API keys yet.</p>}
+        {keys.map((k) => (
+          <div
+            key={k.id}
+            className={`flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2 ${
+              k.is_active ? '' : 'opacity-60'
+            }`}
+          >
+            <KeyRound size={16} className="shrink-0 text-accent" />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm text-content">
+                {k.name}{' '}
+                <code className="ml-1 rounded bg-surface-3 px-1 text-xs text-muted">
+                  {k.prefix}…
+                </code>
+                {!k.is_active && (
+                  <span className="ml-2 rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] text-red-500">
+                    revoked
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 text-[11px] text-muted">
+                Created {fmtDate(k.created_at)} · Last used{' '}
+                {k.last_used_at ? fmtDate(k.last_used_at) : 'never'}
+                {k.expires_at ? ` · Expires ${fmtDate(k.expires_at)}` : ''}
+              </div>
+            </div>
+            {k.is_active && (
+              <button
+                onClick={() => api.revokeApiKey(k.id).then(load)}
+                className="rounded p-1.5 text-muted hover:text-red-600"
+                title="Revoke"
+              >
+                <Trash2 size={15} />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/SettingsDrawer.jsx
+++ b/frontend/src/components/settings/SettingsDrawer.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, BarChart3, SlidersHorizontal } from 'lucide-react'
+import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal } from 'lucide-react'
 import ProviderSettings from './ProviderSettings'
 import ThemeSwitcher from './ThemeSwitcher'
 import MemoryPanel from './MemoryPanel'
@@ -7,6 +7,7 @@ import UsersPanel from './UsersPanel'
 import UsagePanel from './UsagePanel'
 import ConfigPanel from './ConfigPanel'
 import AuthSettingsPanel from './AuthSettingsPanel'
+import ApiKeysPanel from './ApiKeysPanel'
 import DocumentsPanel from '../documents/DocumentsPanel'
 import McpManager from '../mcp/McpManager'
 import ToolManager from '../tools/ToolManager'
@@ -18,6 +19,7 @@ const USER_TABS = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'documents', label: 'Documents', icon: FileText },
   { id: 'memory', label: 'Memory', icon: Brain },
+  { id: 'apikeys', label: 'API Keys', icon: KeySquare },
 ]
 const ADMIN_TABS = [
   { id: 'users', label: 'Users', icon: Users },
@@ -180,6 +182,7 @@ export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
             {tab === 'appearance' && <ThemeSwitcher />}
             {tab === 'documents' && <DocumentsPanel />}
             {tab === 'memory' && <MemoryPanel />}
+            {tab === 'apikeys' && <ApiKeysPanel />}
             {isAdmin && tab === 'mcp' && <McpManager />}
             {isAdmin && tab === 'tools' && <ToolManager />}
             {isAdmin && tab === 'users' && <UsersPanel />}


### PR DESCRIPTION
Closes #5 (Phase 1).

## Scope: Phase 1 only (raw passthrough)

This implements the **raw passthrough** gateway: `POST /v1/chat/completions` (streaming + buffered) and `GET /v1/models`, OpenAI-compatible, authenticated by per-user API keys. **Exactly one model call per request**, so cost is predictable. The agentic endpoint (`POST /v1/agent/completions` with RAG + tools + MCP) is deliberately **out of scope here** — see Phase 2 groundwork below.

Point any OpenAI SDK/tool at `<phlox>/v1` with `Authorization: Bearer phlox-sk-...` and it works unmodified.

## What's included

**Backend**
- `ApiKey` model — SHA-256 **hashed** secret (never recoverable), non-secret `prefix` for display, `scopes`, `is_active`, `expires_at`, `last_used_at`. New table auto-created by `create_all`.
- `app/api_keys.py` — generate (`phlox-sk-<token_urlsafe(32)>`), hash, resolve (active + expiry, best-effort `last_used_at`), CRUD.
- `require_api_key` dependency (Bearer key only — not the browser JWT) resolving to the owning, **billable** `User`.
- `routers/gateway.py` — `/v1/chat/completions` + `/v1/models`, provider-agnostic via `build_provider`, OpenAI error envelope.
- `routers/api_keys.py` — `/api/api-keys` CRUD (JWT auth). Plaintext key returned **once** on create; 404 (not 403) on non-ownership.
- `usage_ledger.record_gateway_usage` — one ledger row per model call.
- `registry.gateway_models()` + `resolve_model()` (accepts `profile/model`, bare id, or default-profile fallback).
- `delete_user_data` now hard-deletes a departing user's API keys; their incurred usage survives in the ledger.

**Frontend** — Settings → **API Keys** tab: mint / list / revoke, copy-once secret reveal with a warning banner.

**Docs** — new `docs/API_GATEWAY.md`, cross-referenced from README, AGENTS, ARCHITECTURE (module map + data model), ROADMAP, OBSERVABILITY, AUTH.

**Tests** — `test_gateway.py` (9 tests): key CRUD, secret-once, revoke, 401 + revoked-key rejection, `/v1/models` catalog, buffered + streaming completions with ledger/cost assertions, empty-messages validation, `resolve_model` unit test.

## Answers to the issue's Open Questions

1. **Usage/cost accounting prerequisite** — Reused the existing `UsageLedger` + `compute_cost` + `model_pricing` layer **inline**, no separate prerequisite PR. Each gateway call appends one ledger row via `record_gateway_usage`, so gateway traffic shows up in the same admin chargeback view (`/api/usage/by-user`) as interactive chat, attributed to the key's owning user + department. The synthetic per-call `request_id` is stored in the ledger's unique `message_id` column, so retried writes can't double-count.
2. **Per-key budgets / rate-limiting** — **Deferred to a follow-up.** Keys carry a `scopes` field as a seam, but enforcement (budgets, RPM limits) is intentionally not in Phase 1.
3. **Streaming token counts** — Falls back to provider-reported `usage` when present; otherwise a local token count is used so a ledger row is still written.

## Phase 2 groundwork

The auth + accounting layer is already built to absorb the agentic endpoint:
- `record_gateway_usage` accepts a `parent_request_id` (stored in the ledger's `conversation_id`) to **group the N model calls of one agentic request** — the seam for `/v1/agent/completions` fan-out cost grouping.
- Usage is captured at the **model-call layer**, not the endpoint, so multi-call requests attribute correctly with no rework.

## Verification
- `ruff check app tests` → clean
- `pytest` → **42 passing**
- `npm run build` → succeeds (benign chunk-size warnings only)
