### PR TITLE
Add opt-in batteries-included sandbox images

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ access — see [docs/AUTH.md](docs/AUTH.md). To run single-user with no login, s
 
 By default code runs in a **local subprocess** (fast, trusts the host). For isolation, set
 `sandbox.runner: container` to run each execution in an ephemeral **Podman/Docker**
-container with CPU/memory/PID limits and network isolation — see [docs/SANDBOX.md](docs/SANDBOX.md).
+container with CPU/memory/PID limits and network isolation. For data-analysis workloads you
+can optionally build the **batteries-included images** (numpy/pandas/matplotlib/… preinstalled)
+so the agent doesn't pip-install packages on every run — see [docs/SANDBOX.md](docs/SANDBOX.md).
 
 ## Production build
 

--- a/docker/sandbox/build.sh
+++ b/docker/sandbox/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Build the Phlox batteries-included sandbox images.
+#
+# These back the CONTAINER sandbox runner (sandbox.runner: container). Point
+# backend/config.yml at the resulting tags:
+#
+#   sandbox:
+#     container:
+#       python_image: phlox-sandbox-python:latest
+#       node_image:   phlox-sandbox-node:latest
+#
+# Re-run after editing the Dockerfiles to pick up new packages. The runner uses
+# whatever the tag currently points at — no Phlox restart needed for image changes.
+set -euo pipefail
+
+# Use the same engine the runner is configured for; default to podman, fall back to docker.
+ENGINE="${ENGINE:-}"
+if [[ -z "$ENGINE" ]]; then
+  if command -v podman >/dev/null 2>&1; then ENGINE=podman
+  elif command -v docker >/dev/null 2>&1; then ENGINE=docker
+  else echo "No podman or docker found on PATH." >&2; exit 1
+  fi
+fi
+
+# Build context is the dir holding the Dockerfiles (they need no extra files).
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo ">> Building phlox-sandbox-python:latest with $ENGINE ..."
+"$ENGINE" build -f "$DIR/python.Dockerfile" -t phlox-sandbox-python:latest "$DIR"
+
+# Build Node image too unless called as: ./build.sh python
+if [[ "${1:-}" != "python" ]]; then
+  echo ">> Building phlox-sandbox-node:latest with $ENGINE ..."
+  "$ENGINE" build -f "$DIR/node.Dockerfile" -t phlox-sandbox-node:latest "$DIR"
+fi
+
+echo ">> Done. Set python_image/node_image in backend/config.yml to the tags above."

--- a/docker/sandbox/node.Dockerfile
+++ b/docker/sandbox/node.Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+#
+# Phlox "batteries-included" Node sandbox image.
+#
+# Used by the CONTAINER sandbox runner as `node_image` so the agent's execute_node
+# tool can require() common libraries without installing them per call.
+#
+# Build:   ./docker/sandbox/build.sh            (or: podman build -f docker/sandbox/node.Dockerfile -t phlox-sandbox-node:latest .)
+# Wire up: set sandbox.container.node_image: phlox-sandbox-node:latest in backend/config.yml
+#
+# Node resolves bare require('lodash') against NODE_PATH, so we install the common
+# libs into a global node_modules and point NODE_PATH at it. The agent's code runs
+# from /work (bind-mounted workspace) but still finds these globals.
+
+FROM node:22-slim
+
+# Common utility libraries, installed into a fixed global prefix.
+# Versions pinned for reproducible rebuilds — bump deliberately and re-run build.sh.
+RUN mkdir -p /opt/node_modules \
+    && cd /opt \
+    && npm install --no-fund --no-audit --prefix /opt \
+        lodash@4.18.1 \
+        axios@1.18.0 \
+        dayjs@1.11.21 \
+        mathjs@15.2.0 \
+        d3@7.9.0 \
+        csv-parse@7.0.0 \
+        csv-stringify@6.8.0 \
+    && npm cache clean --force
+
+# require() in agent code (cwd /work) resolves these from the global path.
+ENV NODE_PATH=/opt/node_modules
+
+WORKDIR /work

--- a/docker/sandbox/python.Dockerfile
+++ b/docker/sandbox/python.Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+#
+# Phlox "batteries-included" Python sandbox image.
+#
+# Used by the CONTAINER sandbox runner as `python_image` so the agent's
+# execute_python / run_shell tools start with the common data-analysis stack
+# already installed — no per-call `pip install numpy ... matplotlib ...` dance.
+#
+# Build:   ./docker/sandbox/build.sh            (or: podman build -f docker/sandbox/python.Dockerfile -t phlox-sandbox-python:latest .)
+# Wire up: set sandbox.container.python_image: phlox-sandbox-python:latest in backend/config.yml
+#
+# Once packages are baked in here you can also set sandbox.container.network: none
+# for stronger isolation — the agent no longer needs the network to fetch them.
+
+FROM python:3.12-slim
+
+# OS-level tools the agent may want from run_shell, plus fonts so matplotlib can
+# render text (slim ships none), and ca-certificates for TLS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git curl wget jq unzip \
+        ca-certificates \
+        fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+# Standard data / analysis stack. Versions pinned for reproducible rebuilds — bump
+# deliberately and re-run docker/sandbox/build.sh.
+# Matplotlib defaults to the non-interactive Agg backend with no display, so plots
+# saved to /work (e.g. savefig('plot.png')) are captured as artifacts.
+RUN pip install --no-cache-dir \
+        numpy==2.5.0 \
+        pandas==3.0.3 \
+        scipy==1.18.0 \
+        matplotlib==3.11.0 \
+        seaborn==0.13.2 \
+        scikit-learn==1.9.0 \
+        statsmodels==0.14.6 \
+        openpyxl==3.1.5 \
+        XlsxWriter==3.2.9 \
+        pypdf==6.13.3 \
+        python-docx==1.2.0 \
+        pillow==12.2.0 \
+        requests==2.34.2 \
+        httpx==0.28.1 \
+        beautifulsoup4==4.15.0 \
+        lxml==6.1.1 \
+        sympy==1.14.0 \
+        networkx==3.6.1 \
+        tabulate==0.10.0
+
+# Headless matplotlib by default; keep Python output unbuffered for live logs.
+ENV MPLBACKEND=Agg \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /work

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -52,6 +52,52 @@ The container runner targets the **Docker-compatible CLI**, so it works with **P
    ```
 3. Set `sandbox.runner: container` and restart the backend.
 
+## Batteries-included images (opt-in)
+
+Phlox **defaults to the small official `python:3.12-slim` / `node:22-slim` images** so a
+fresh install pulls fast and just works. They're bare, though, which is fine for light
+scripting but painful for data work.
+
+**Why you'd want the batteries-included images:** every execution runs in a fresh `--rm`
+container, so anything the agent `pip install`s does **not** persist to the next call. A
+"analyze this CSV and plot it" request then turns into a slow loop of *import error →
+install numpy → import error → install pandas → install matplotlib …*, burning tool-call
+rounds and only working at all with `network: bridge` (network egress enabled). Baking the
+common stack into the image removes that loop entirely **and** lets you switch to
+`network: none` — the most secure mode — since the agent no longer needs the network to
+fetch packages.
+
+This is **opt-in**: build the images, then point the config at them. Phlox ships the
+definitions under [`docker/sandbox/`](../docker/sandbox/):
+
+```bash
+./docker/sandbox/build.sh          # builds phlox-sandbox-python:latest + phlox-sandbox-node:latest
+# or just Python:  ./docker/sandbox/build.sh python
+```
+
+Then point the runner at them in `config.yml`:
+
+```yaml
+sandbox:
+  runner: container
+  container:
+    python_image: phlox-sandbox-python:latest
+    node_image:   phlox-sandbox-node:latest
+    network: bridge          # safe to lock down now — packages are already in the image
+```
+
+The Python image includes numpy, pandas, scipy, matplotlib, seaborn, scikit-learn,
+statsmodels, openpyxl/xlsxwriter, pypdf, python-docx, pillow, requests/httpx,
+beautifulsoup4/lxml, sympy, networkx, tabulate — plus `git/curl/wget/jq` and fonts for
+matplotlib. The Node image preinstalls lodash, axios, dayjs, mathjs, d3, csv-parse
+(via `NODE_PATH`). Edit the Dockerfiles and re-run `build.sh` to add more; the runner
+picks up the new image on the next execution with no Phlox restart (image tag is read at
+run time). Add packages your workflows need rather than leaving the agent to install them.
+
+> With packages baked in you can set `network: none` — the most secure mode — because the
+> agent no longer needs egress to fetch them. Keep `bridge` only if you still want the
+> agent to install ad-hoc packages at runtime.
+
 ## Security properties
 
 - **Filesystem:** only the conversation workspace is mounted (`/work`); the rest of the


### PR DESCRIPTION
## What

Adds prebuilt, **opt-in** "batteries-included" container images for the sandbox runner, with the common data-analysis stack preinstalled. The small official images (`python:3.12-slim` / `node:22-slim`) remain the default — this is purely additive.

New files under `docker/sandbox/`:

- **`python.Dockerfile`** — `python:3.12-slim` + numpy, pandas, scipy, matplotlib, seaborn, scikit-learn, statsmodels, openpyxl/xlsxwriter, pypdf, python-docx, pillow, requests/httpx, beautifulsoup4/lxml, sympy, networkx, tabulate; plus matplotlib fonts and `git`/`curl`/`wget`/`jq`. Versions pinned for reproducible rebuilds.
- **`node.Dockerfile`** — `node:22-slim` + lodash, axios, dayjs, mathjs, d3, csv-parse/csv-stringify, exposed via `NODE_PATH`. Pinned.
- **`build.sh`** — builds both tags (`build.sh python` for Python only), auto-detecting podman/docker.

Docs:
- `docs/SANDBOX.md` — new "Batteries-included images (opt-in)" section: why, how to build, how to configure.
- `README.md` — one-line pointer to the opt-in section.

## Why

With `sandbox.runner: container`, every code execution runs in a fresh `--rm` container. On the bare slim images, a data task ("analyze this CSV and plot it") devolves into a loop of *import error → `pip install` → import error → `pip install` …*. Installs don't persist across ephemeral containers, so the agent burns tool-call rounds rediscovering the same missing packages — and it only works at all with `network: bridge`.

Baking the stack into an image removes the loop entirely **and** lets users switch to `network: none` (the most secure mode), since the agent no longer needs egress to fetch packages.

## How to use

No code changes — `python_image` / `node_image` are already config-driven and read per execution:

```bash
./docker/sandbox/build.sh
```

```yaml
sandbox:
  runner: container
  container:
    python_image: phlox-sandbox-python:latest
    node_image:   phlox-sandbox-node:latest
    network: none
```

## Testing

- `build.sh` builds both images cleanly with podman (python ~903 MB, node ~281 MB).
- Verified the full Python stack imports and `matplotlib.savefig('plot.png')` runs with `--network none`, with the artifact landing back on the host via the `/work` bind mount.
- Verified Node resolves `require('lodash')` / `require('dayjs')` from `NODE_PATH` with `--network none`.
- Rebuilt from the pinned Dockerfiles to confirm the pins resolve.

## Notes

- Default behavior is unchanged: thin images stay the default; this is opt-in.
- Reminder for users with an existing admin override: the sandbox `container` block (including images) can be overridden live in the DB via Settings → Admin → Configuration, which takes precedence over `config.yml`.