### PR TITLE
Spend budgets: monthly cost caps per user/department with warnings + enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ models).
   **chargeback** view: usage by **month × user × department × model**, CSV export for
   finance, and a durable ledger that keeps a departed user's costs billable after their
   account is deleted. See [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md).
+- 🧮 **Spend budgets** — admins set a monthly USD cap per **user** or **department**; users
+  get a warning banner at an adjustable threshold (default 90%) and **priced** models are
+  blocked once a budget is reached (free models stay usable), enforced for both chat and the
+  API gateway and resetting each month. See [docs/BUDGETS.md](docs/BUDGETS.md).
 - ⚙️ **Live admin configuration** — edit provider profiles (keys write-only), model
   pricing, resilience, generation defaults, and sandbox limits from an admin-only
   **Configuration** panel, applied without a server restart. `config.yml` remains the seed.
@@ -73,6 +77,7 @@ models).
 | [docs/AUTH.md](docs/AUTH.md) | Local accounts, roles, multi-user isolation, **Entra ID SSO** setup |
 | [docs/SANDBOX.md](docs/SANDBOX.md) | Local vs **Podman/Docker container** code-execution sandbox |
 | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) | Token usage/cost, structured logs, OpenTelemetry tracing |
+| [docs/BUDGETS.md](docs/BUDGETS.md) | Monthly spend budgets per user/department: warnings + enforcement |
 | [docs/API_GATEWAY.md](docs/API_GATEWAY.md) | OpenAI-compatible API gateway: API keys + `/v1/*` endpoints |
 | [docs/MCP.md](docs/MCP.md) | Connecting MCP servers |
 | [docs/THEMING.md](docs/THEMING.md) | The theme token system + adding themes |
@@ -88,7 +93,7 @@ exec, auth, SQLite persistence) and a **React/Vite** frontend. Full details in
 ```
 backend/   FastAPI app (app/), config.yml, SQLite + Qdrant under data/
 frontend/  React + Vite + Tailwind SPA
-docs/      ARCHITECTURE, ROADMAP, DEPLOYMENT, DOCKER, AUTH, SANDBOX, MCP, THEMING, ADDING_A_*
+docs/      ARCHITECTURE, ROADMAP, DEPLOYMENT, DOCKER, AUTH, SANDBOX, MCP, THEMING, BUDGETS, ADDING_A_*
 scripts/   dev.ps1 / dev.sh
 ```
 

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -71,7 +71,7 @@ def delete_user_data(db: Session, user_id: str) -> dict:
     import shutil
 
     from app.config import UPLOADS_DIR, WORKSPACES_DIR
-    from app.models import ApiKey, Conversation, Document, Memory, Setting
+    from app.models import ApiKey, Budget, Conversation, Document, Memory, Setting
 
     counts = {"conversations": 0, "documents": 0, "memories": 0, "api_keys": 0}
 
@@ -107,6 +107,16 @@ def delete_user_data(db: Session, user_id: str) -> dict:
     # Per-user settings are keyed "<user_id>:<key>".
     for s in db.query(Setting).filter(Setting.key.like(f"{user_id}:%")).all():
         db.delete(s)
+
+    # Drop a user-scoped spend budget so it doesn't linger as an orphaned config row.
+    # Department budgets are NOT touched — they aren't tied to a single account, and the
+    # ledger still attributes this user's past spend to their department for chargeback.
+    for b in (
+        db.query(Budget)
+        .filter(Budget.scope_type == "user", Budget.scope_value == user_id)
+        .all()
+    ):
+        db.delete(b)
 
     # NOTE: UsageLedger rows are intentionally NOT deleted here. They are the durable
     # chargeback record (usage metadata only, identity snapshotted at write time) and must

--- a/backend/app/budgets.py
+++ b/backend/app/budgets.py
@@ -1,0 +1,155 @@
+"""Monthly spend budgets: current-month spend, status, and enforcement.
+
+Budgets (``models.Budget``) cap a user's or department's USD spend per UTC calendar month.
+Spend is computed live from the durable ``UsageLedger`` (the same metadata that drives
+chargeback), so there is no counter to reset — the month window simply rolls forward.
+
+Enforcement is **most-restrictive-wins**: a user may be covered by both their own user
+budget and their department budget; a turn is blocked if *either* is at/over its limit. Only
+**priced** models (those with an ``observability.pricing`` entry) count toward spend and only
+priced models are blocked — free/local models stay usable.
+
+Because token cost is only known after a turn completes, enforcement blocks the *next* turn
+once you are at/over budget rather than cutting off mid-turn (the turn that crosses the line
+is allowed to finish). See docs/BUDGETS.md.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models import Budget, UsageLedger, User
+
+
+def month_bounds(now: datetime | None = None) -> tuple[datetime, datetime]:
+    """Return ``[start_of_month, start_of_next_month)`` in UTC for ``now`` (default: now)."""
+    now = now or datetime.now(timezone.utc)
+    start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
+    # First day of next month (December wraps to January of the next year).
+    if start.month == 12:
+        nxt = start.replace(year=start.year + 1, month=1)
+    else:
+        nxt = start.replace(month=start.month + 1)
+    return start, nxt
+
+
+def priced_models() -> set[str]:
+    """Model ids that have a configured price (and so count toward spend / can be blocked)."""
+    from app.config import get_observability_config
+
+    return set((get_observability_config().get("pricing") or {}).keys())
+
+
+def model_is_priced(model: str | None) -> bool:
+    return bool(model) and model in priced_models()
+
+
+def current_month_spend(
+    db: Session, *, scope_type: str, scope_value: str, now: datetime | None = None
+) -> float:
+    """Sum ``cost_usd`` from the ledger for one scope over the current UTC month.
+
+    ``user`` scope matches ledger rows by the snapshotted ``user_id``; ``department`` scope
+    matches by the snapshotted ``department`` name (so a user reassigned mid-month bills the
+    department they were in at the time of each turn — consistent with the chargeback view).
+    """
+    lo, hi = month_bounds(now)
+    q = db.query(func.coalesce(func.sum(UsageLedger.cost_usd), 0.0)).filter(
+        UsageLedger.created_at >= lo, UsageLedger.created_at < hi
+    )
+    if scope_type == "user":
+        q = q.filter(UsageLedger.user_id == scope_value)
+    else:
+        q = q.filter(UsageLedger.department == scope_value)
+    return float(q.scalar() or 0.0)
+
+
+def applicable_budgets(db: Session, user: User) -> list[Budget]:
+    """Active budgets that cover ``user``: their own user budget + their department budget."""
+    out: list[Budget] = []
+    ub = (
+        db.query(Budget)
+        .filter(Budget.is_active.is_(True), Budget.scope_type == "user",
+                Budget.scope_value == user.id)
+        .first()
+    )
+    if ub:
+        out.append(ub)
+    if user.department:
+        db_ = (
+            db.query(Budget)
+            .filter(Budget.is_active.is_(True), Budget.scope_type == "department",
+                    Budget.scope_value == user.department)
+            .first()
+        )
+        if db_:
+            out.append(db_)
+    return out
+
+
+def _budget_cell(db: Session, b: Budget, now: datetime | None = None) -> dict:
+    spent = current_month_spend(db, scope_type=b.scope_type, scope_value=b.scope_value, now=now)
+    limit = float(b.limit_usd or 0.0)
+    pct = (spent / limit * 100.0) if limit > 0 else 0.0
+    over = limit > 0 and spent >= limit
+    warn = bool(b.warn_pct) and limit > 0 and pct >= b.warn_pct and not over
+    return {
+        "id": b.id,
+        "scope_type": b.scope_type,
+        "scope_value": b.scope_value,
+        "limit_usd": round(limit, 4),
+        "spent_usd": round(spent, 4),
+        "remaining_usd": round(max(limit - spent, 0.0), 4),
+        "pct": round(pct, 1),
+        "warn_pct": b.warn_pct,
+        "over": over,
+        "warn": warn,
+    }
+
+
+def budget_status(db: Session, user: User, now: datetime | None = None) -> dict:
+    """The signed-in user's budget status, for the UI banner and pre-send checks.
+
+    ``blocked`` is true if any applicable budget is at/over its limit (priced models will be
+    refused). ``warn`` is true if any applicable budget has crossed its warn threshold but
+    none are over. ``worst`` is the closest-to-limit applicable budget. ``priced_models``
+    lets the client mark/disable exactly the models that would be refused.
+    """
+    cells = [_budget_cell(db, b, now=now) for b in applicable_budgets(db, user)]
+    blocked = any(c["over"] for c in cells)
+    warn = (not blocked) and any(c["warn"] for c in cells)
+    worst = max(cells, key=lambda c: c["pct"], default=None)
+    return {
+        "budgets": cells,
+        "blocked": blocked,
+        "warn": warn,
+        "worst": worst,
+        "priced_models": sorted(priced_models()),
+    }
+
+
+def enforce_budget(db: Session, user: User, model: str | None) -> None:
+    """Raise HTTP 402 if ``user`` is over budget and ``model`` is priced. No-op otherwise.
+
+    Called at both model-call choke points (interactive chat + the gateway) so API-key
+    traffic is gated identically to the UI. Unpriced models are always allowed.
+    """
+    if not model_is_priced(model):
+        return
+    status = budget_status(db, user)
+    if not status["blocked"]:
+        return
+    worst = status["worst"] or {}
+    scope = "department" if worst.get("scope_type") == "department" else "your"
+    raise HTTPException(
+        402,
+        detail=(
+            f"Monthly budget exceeded for {scope} budget "
+            f"(${worst.get('spent_usd', 0):.2f} of ${worst.get('limit_usd', 0):.2f}). "
+            f"Access to priced models is paused until the budget resets next month. "
+            f"Models without an assigned cost remain available."
+        ),
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.routers import (
     api_keys,
     attachments,
     auth,
+    budgets,
     chat,
     checkpoints,
     conversations,
@@ -119,7 +120,8 @@ app.add_middleware(
 )
 
 for r in (auth, chat, conversations, providers, settings, documents, mcp, tools, files,
-          memories, checkpoints, attachments, usage, admin_config, api_keys, gateway):
+          memories, checkpoints, attachments, usage, admin_config, api_keys, gateway,
+          budgets):
     app.include_router(r.router)
 
 # Structured request logging (always) + OpenTelemetry tracing (if configured).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -223,6 +224,42 @@ class UsageLedger(Base):
     total_tokens: Mapped[int] = mapped_column(Integer, default=0)
     cost_usd: Mapped[float | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_now, index=True)
+
+
+class Budget(Base):
+    """A monthly USD spend cap for a single user or a whole department.
+
+    Enforced against the durable :class:`UsageLedger`: a turn is blocked once the current
+    UTC calendar month's summed ``cost_usd`` for the budget's scope reaches ``limit_usd``,
+    but only for **priced** models (those with an ``observability.pricing`` entry) — free
+    models stay usable. ``warn_pct`` drives the UI warning banner before the hard cap.
+
+    FK-free for parity with the rest of the per-user model: ``scope_value`` holds a
+    ``User.id`` (scope_type ``user``) or a department name (scope_type ``department``). A
+    user can be covered by both a user budget and their department budget; enforcement is
+    most-restrictive-wins. ``is_active`` is a soft on/off that keeps the row.
+
+    There is no stored counter to reset each month — "spend this month" is always a
+    date-bounded query over the ledger, so it rolls forward automatically.
+    """
+
+    __tablename__ = "budgets"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
+    # scope_type: user | department
+    scope_type: Mapped[str] = mapped_column(String(20))
+    # User.id when scope_type == 'user'; department name when 'department'.
+    scope_value: Mapped[str] = mapped_column(String(200))
+    limit_usd: Mapped[float] = mapped_column(default=0.0)
+    # Percent of the limit at which to warn the user (UI banner). 0 disables the warning.
+    warn_pct: Mapped[int] = mapped_column(Integer, default=90)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=_now, onupdate=_now)
+
+    __table_args__ = (
+        UniqueConstraint("scope_type", "scope_value", name="uq_budget_scope"),
+    )
 
 
 class ApiKey(Base):

--- a/backend/app/routers/budgets.py
+++ b/backend/app/routers/budgets.py
@@ -1,0 +1,114 @@
+"""Admin CRUD for monthly spend budgets (Settings → Admin → Budgets).
+
+Budgets cap a user's or department's USD spend per UTC calendar month; enforcement lives in
+:mod:`app.budgets` and is applied at the chat + gateway model-call choke points. This router
+is admin-only and surfaces each budget's **current-month spend** alongside its config so the
+admin can see headroom at a glance. See docs/BUDGETS.md.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.auth.deps import require_admin
+from app.budgets import current_month_spend
+from app.database import get_db
+from app.models import Budget, User
+from app.schemas import BudgetCreate, BudgetUpdate
+
+router = APIRouter(prefix="/api/admin/budgets", tags=["admin-budgets"])
+
+
+def _serialize(db: Session, b: Budget) -> dict:
+    spent = current_month_spend(db, scope_type=b.scope_type, scope_value=b.scope_value)
+    limit = float(b.limit_usd or 0.0)
+    # Resolve a friendly label for user-scoped budgets (department scope is self-describing).
+    label = b.scope_value
+    if b.scope_type == "user":
+        u = db.get(User, b.scope_value)
+        if u:
+            label = u.display_name or u.username
+    return {
+        "id": b.id,
+        "scope_type": b.scope_type,
+        "scope_value": b.scope_value,
+        "scope_label": label,
+        "limit_usd": round(limit, 4),
+        "warn_pct": b.warn_pct,
+        "is_active": b.is_active,
+        "spent_usd": round(spent, 4),
+        "remaining_usd": round(max(limit - spent, 0.0), 4),
+        "pct": round((spent / limit * 100.0) if limit > 0 else 0.0, 1),
+    }
+
+
+@router.get("")
+def list_budgets(db: Session = Depends(get_db), _admin: User = Depends(require_admin)):
+    """All budgets with their current-month spend. Departments first, then users."""
+    rows = db.query(Budget).order_by(Budget.scope_type, Budget.scope_value).all()
+    return {"budgets": [_serialize(db, b) for b in rows]}
+
+
+@router.post("")
+def create_budget(
+    body: BudgetCreate, db: Session = Depends(get_db), _admin: User = Depends(require_admin)
+):
+    if body.scope_type not in ("user", "department"):
+        raise HTTPException(422, "scope_type must be 'user' or 'department'")
+    if not body.scope_value.strip():
+        raise HTTPException(422, "scope_value is required")
+    if body.limit_usd < 0:
+        raise HTTPException(422, "limit_usd must be >= 0")
+    if not (0 <= body.warn_pct <= 100):
+        raise HTTPException(422, "warn_pct must be between 0 and 100")
+    b = Budget(
+        scope_type=body.scope_type,
+        scope_value=body.scope_value.strip(),
+        limit_usd=body.limit_usd,
+        warn_pct=body.warn_pct,
+        is_active=body.is_active,
+    )
+    db.add(b)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, "A budget for this scope already exists")
+    db.refresh(b)
+    return _serialize(db, b)
+
+
+@router.patch("/{budget_id}")
+def update_budget(
+    budget_id: str,
+    body: BudgetUpdate,
+    db: Session = Depends(get_db),
+    _admin: User = Depends(require_admin),
+):
+    b = db.get(Budget, budget_id)
+    if not b:
+        raise HTTPException(404, "Budget not found")
+    if body.limit_usd is not None:
+        if body.limit_usd < 0:
+            raise HTTPException(422, "limit_usd must be >= 0")
+        b.limit_usd = body.limit_usd
+    if body.warn_pct is not None:
+        if not (0 <= body.warn_pct <= 100):
+            raise HTTPException(422, "warn_pct must be between 0 and 100")
+        b.warn_pct = body.warn_pct
+    if body.is_active is not None:
+        b.is_active = body.is_active
+    db.commit()
+    db.refresh(b)
+    return _serialize(db, b)
+
+
+@router.delete("/{budget_id}", status_code=204)
+def delete_budget(
+    budget_id: str, db: Session = Depends(get_db), _admin: User = Depends(require_admin)
+):
+    b = db.get(Budget, budget_id)
+    if b:
+        db.delete(b)
+        db.commit()

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -84,6 +84,12 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), user: User = Depends(g
     profile = req.profile or settings["active_profile"]
     model = req.model or settings.get("model")
 
+    # Budget gate: refuse a priced model once this user (or their department) is over their
+    # monthly cap. Runs before any message is persisted so a blocked turn writes nothing.
+    from app.budgets import enforce_budget
+
+    enforce_budget(db, user, model)
+
     conversation: Conversation | None = None
     if req.conversation_id:
         conversation = db.get(Conversation, req.conversation_id)

--- a/backend/app/routers/gateway.py
+++ b/backend/app/routers/gateway.py
@@ -24,7 +24,7 @@ import time
 import uuid
 from collections.abc import Iterator
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -83,13 +83,26 @@ def _record(db: Session, *, request_id: str, user_id: str, model: str, usage: di
 
 
 @router.get("/models")
-def list_v1_models(_user: User = Depends(require_api_key)):
-    """OpenAI-compatible model list. ``id`` is the fully-qualified ``profile/model``."""
+def list_v1_models(
+    db: Session = Depends(get_db), user: User = Depends(require_api_key)
+):
+    """OpenAI-compatible model list. ``id`` is the fully-qualified ``profile/model``.
+
+    When the caller is over their monthly budget, priced models are annotated with a
+    non-standard ``phlox_blocked: true`` (clients can ignore it; a blocked call still
+    returns a 402). Free models are never blocked.
+    """
+    from app.budgets import budget_status, model_is_priced
+
     created = int(time.time())
+    blocked = budget_status(db, user)["blocked"]
     return {
         "object": "list",
         "data": [
-            {"id": m["id"], "object": "model", "created": created, "owned_by": m["profile"]}
+            {
+                "id": m["id"], "object": "model", "created": created, "owned_by": m["profile"],
+                "phlox_blocked": blocked and model_is_priced(m["model"]),
+            }
             for m in gateway_models()
         ],
     }
@@ -107,6 +120,14 @@ def chat_completions(
         profile, model = resolve_model(req.model)
     except ValueError as e:
         return _err(404, str(e), etype="model_not_found")
+    # Budget gate: refuse a priced model once the key's owner (or their department) is over
+    # their monthly cap. Returned in OpenAI error shape so SDKs surface it cleanly.
+    from app.budgets import enforce_budget
+
+    try:
+        enforce_budget(db, user, model)
+    except HTTPException as e:
+        return _err(402, e.detail, etype="insufficient_quota")
     try:
         provider = build_provider(profile, model)
     except Exception as e:  # noqa: BLE001

--- a/backend/app/routers/usage.py
+++ b/backend/app/routers/usage.py
@@ -62,6 +62,18 @@ def usage_summary(db: Session = Depends(get_db), user: User = Depends(get_curren
     }
 
 
+@router.get("/budget")
+def my_budget_status(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    """The signed-in user's monthly budget status (applicable user + department budgets).
+
+    Drives the chat warning banner and the pre-send block. Returns empty ``budgets`` when no
+    budget covers this user. See :mod:`app.budgets` and docs/BUDGETS.md.
+    """
+    from app.budgets import budget_status
+
+    return budget_status(db, user)
+
+
 @router.get("/by-user")
 def usage_by_user(
     start: str | None = Query(None, description="ISO date/datetime lower bound (inclusive)"),

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -196,3 +196,17 @@ class SandboxLimits(BaseModel):
 
 class SandboxUpdate(BaseModel):
     container: SandboxLimits
+
+
+class BudgetCreate(BaseModel):
+    scope_type: str                  # "user" | "department"
+    scope_value: str                 # user id, or department name
+    limit_usd: float
+    warn_pct: int = 90
+    is_active: bool = True
+
+
+class BudgetUpdate(BaseModel):
+    limit_usd: float | None = None
+    warn_pct: int | None = None
+    is_active: bool | None = None

--- a/backend/tests/test_budgets.py
+++ b/backend/tests/test_budgets.py
@@ -1,0 +1,197 @@
+"""Tests for monthly spend budgets: status, enforcement, and admin CRUD.
+
+Auth is disabled in the test config, so the TestClient acts as the synthetic dev admin
+(``user.id == "local"``, no department). Budgets and ledger rows are written directly and
+cleaned up per-test so state doesn't leak into the session-scoped DB.
+"""
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+PRICED_MODEL = "budget-test-model"
+
+
+@pytest.fixture
+def clean_budgets():
+    """Reset budgets, ledger, and the pricing override before and after each test."""
+    def _reset():
+        from app import app_config
+        from app.database import SessionLocal
+        from app.models import AppConfig, Budget, UsageLedger
+        s = SessionLocal()
+        try:
+            s.query(Budget).delete()
+            s.query(UsageLedger).delete()
+            s.query(AppConfig).delete()
+            s.commit()
+        finally:
+            s.close()
+        app_config.invalidate()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _price_the_model():
+    """Give PRICED_MODEL a configured price so it counts as 'priced' / blockable."""
+    from app import app_config
+    app_config.set_section("pricing", {PRICED_MODEL: {"input": 1.0, "output": 1.0}})
+
+
+def _add_spend(user_id, cost, *, department=None, model=PRICED_MODEL, when=None):
+    from app.database import SessionLocal
+    from app.models import UsageLedger
+    s = SessionLocal()
+    try:
+        s.add(UsageLedger(
+            message_id=f"m-{uuid.uuid4().hex}",
+            user_id=user_id, department=department, model=model,
+            input_tokens=100, output_tokens=100, total_tokens=200, cost_usd=cost,
+            created_at=when or datetime.now(timezone.utc).replace(tzinfo=None),
+        ))
+        s.commit()
+    finally:
+        s.close()
+
+
+# -- month window --------------------------------------------------------
+def test_month_bounds_wraps_december():
+    from app.budgets import month_bounds
+    lo, hi = month_bounds(datetime(2025, 12, 15, tzinfo=timezone.utc))
+    assert (lo.year, lo.month, lo.day) == (2025, 12, 1)
+    assert (hi.year, hi.month) == (2026, 1)
+
+
+def test_spend_excludes_other_months(clean_budgets):
+    from app.budgets import current_month_spend
+    from app.database import SessionLocal
+    _add_spend("local", 2.0)
+    # A row from a clearly prior month must not count toward this month.
+    _add_spend("local", 99.0, when=datetime(2000, 1, 1))
+    s = SessionLocal()
+    try:
+        spend = current_month_spend(s, scope_type="user", scope_value="local")
+    finally:
+        s.close()
+    assert spend == 2.0
+
+
+# -- status + enforcement ------------------------------------------------
+def test_budget_status_warns_then_blocks(client, clean_budgets):
+    from app.database import SessionLocal
+    from app.models import Budget
+    _price_the_model()
+    s = SessionLocal()
+    s.add(Budget(scope_type="user", scope_value="local", limit_usd=5.0, warn_pct=90))
+    s.commit()
+    s.close()
+
+    # Under the warn threshold: not warning, not blocked.
+    _add_spend("local", 1.0)
+    st = client.get("/api/usage/budget").json()
+    assert st["blocked"] is False and st["warn"] is False
+    assert PRICED_MODEL in st["priced_models"]
+
+    # Cross 90% ($4.50 of $5): warn, still not blocked.
+    _add_spend("local", 3.6)
+    st = client.get("/api/usage/budget").json()
+    assert st["warn"] is True and st["blocked"] is False
+
+    # Reach the cap ($5+): blocked.
+    _add_spend("local", 1.0)
+    st = client.get("/api/usage/budget").json()
+    assert st["blocked"] is True
+
+
+def test_chat_blocked_for_priced_model_over_budget(client, clean_budgets):
+    from app.database import SessionLocal
+    from app.models import Budget
+    _price_the_model()
+    s = SessionLocal()
+    s.add(Budget(scope_type="user", scope_value="local", limit_usd=1.0, warn_pct=90))
+    s.commit()
+    s.close()
+    _add_spend("local", 2.0)  # over the $1 cap
+
+    r = client.post("/api/chat", json={"message": "hi", "model": PRICED_MODEL})
+    assert r.status_code == 402
+    assert "budget" in r.text.lower()
+
+
+def test_chat_allows_unpriced_model_over_budget(client, clean_budgets):
+    """An over-budget user can still use a model with no assigned cost."""
+    from app.database import SessionLocal
+    from app.models import Budget
+    _price_the_model()
+    s = SessionLocal()
+    s.add(Budget(scope_type="user", scope_value="local", limit_usd=1.0, warn_pct=90))
+    s.commit()
+    s.close()
+    _add_spend("local", 2.0)
+
+    # Free model => the budget gate passes (the call later fails at the unreachable
+    # provider, but NOT with a 402 budget rejection).
+    r = client.post("/api/chat", json={"message": "hi", "model": "free-local-model"})
+    assert r.status_code != 402
+
+
+# -- admin CRUD ----------------------------------------------------------
+def test_admin_budget_crud(client, clean_budgets):
+    created = client.post("/api/admin/budgets", json={
+        "scope_type": "department", "scope_value": "Research", "limit_usd": 5.0,
+    }).json()
+    assert created["scope_type"] == "department" and created["limit_usd"] == 5.0
+
+    listed = client.get("/api/admin/budgets").json()["budgets"]
+    assert any(b["scope_value"] == "Research" for b in listed)
+
+    upd = client.patch(f"/api/admin/budgets/{created['id']}", json={"limit_usd": 10.0}).json()
+    assert upd["limit_usd"] == 10.0
+
+    # Duplicate scope is rejected.
+    dup = client.post("/api/admin/budgets", json={
+        "scope_type": "department", "scope_value": "Research", "limit_usd": 1.0,
+    })
+    assert dup.status_code == 409
+
+    assert client.delete(f"/api/admin/budgets/{created['id']}").status_code == 204
+
+
+def test_user_delete_removes_user_budget_keeps_department(clean_budgets):
+    """Deleting a user drops their user-scoped budget but leaves department budgets."""
+    from app.auth.service import delete_user_data
+    from app.database import SessionLocal
+    from app.models import Budget, User
+    s = SessionLocal()
+    try:
+        s.add(User(id="u-del", username="to-delete"))
+        s.add(Budget(scope_type="user", scope_value="u-del", limit_usd=5.0))
+        s.add(Budget(scope_type="department", scope_value="Eng", limit_usd=10.0))
+        s.commit()
+        delete_user_data(s, "u-del")
+        scopes = {(b.scope_type, b.scope_value) for b in s.query(Budget).all()}
+        assert ("user", "u-del") not in scopes
+        assert ("department", "Eng") in scopes
+    finally:
+        s.query(User).filter(User.id == "u-del").delete()
+        s.commit()
+        s.close()
+
+
+def test_department_spend_attribution(client, clean_budgets):
+    """A department budget sums spend snapshotted to that department in the ledger."""
+    from app.database import SessionLocal
+    from app.models import Budget
+    s = SessionLocal()
+    s.add(Budget(scope_type="department", scope_value="Eng", limit_usd=10.0))
+    s.commit()
+    s.close()
+    _add_spend("alice", 3.0, department="Eng")
+    _add_spend("bob", 4.0, department="Eng")
+    _add_spend("carol", 5.0, department="Other")
+
+    listed = client.get("/api/admin/budgets").json()["budgets"]
+    eng = next(b for b in listed if b["scope_value"] == "Eng")
+    assert eng["spent_usd"] == 7.0

--- a/docs/API_GATEWAY.md
+++ b/docs/API_GATEWAY.md
@@ -45,6 +45,10 @@ Lists every callable model across all profiles. Each `id` is fully-qualified
 `profile/model` (since the same model id can exist under multiple profiles); a bare model
 id also works and resolves against the catalog (falling back to the default profile).
 
+When the key's owner is over a monthly **spend budget**, priced models are annotated with a
+non-standard `"phlox_blocked": true` (clients may ignore it; calling a blocked model still
+returns a 402). See [BUDGETS.md](BUDGETS.md).
+
 ### `POST /v1/chat/completions`
 
 OpenAI-spec request/response. Supports streaming (`"stream": true`, SSE
@@ -52,6 +56,11 @@ OpenAI-spec request/response. Supports streaming (`"stream": true`, SSE
 Honored fields: `model`, `messages`, `temperature`, `max_tokens`, `stream`. Other fields
 (`top_p`, `stop`, `user`, …) are accepted and ignored in Phase 1. **Tools/RAG/agentic
 behavior are intentionally not exposed here** — that's Phase 2's `/v1/agent/completions`.
+
+If the key's owner (or their department) is over a monthly **spend budget** and the
+requested model is priced, the call is rejected with **HTTP 402** in the OpenAI error
+envelope (`type: "insufficient_quota"`) before any upstream call. Models with no assigned
+cost are never blocked. See [BUDGETS.md](BUDGETS.md).
 
 ### Examples
 
@@ -92,7 +101,8 @@ gateway model call appends one row to the durable **`UsageLedger`**
 
 Gateway usage therefore appears automatically in the admin **Usage & Cost** view
 (`GET /api/usage/by-user`, "usage by month × user × department × model") and the per-user
-`GET /api/usage` meter — no extra wiring.
+`GET /api/usage` meter — no extra wiring. The same ledger also drives **spend budgets**, so
+gateway spend counts toward a user's/department's monthly cap. See [BUDGETS.md](BUDGETS.md).
 
 ## 4. Where it lives (code map)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,8 +84,9 @@ deals with provider-specific shapes.
 | **RAG** | `rag/ingest.py`, `embed.py`, `retrieve.py`, `store.py` | Parse → chunk → embed → **Qdrant** vector search (`VectorStore` seam) |
 | **MCP** | `mcp/manager.py` | Connect MCP servers, proxy their tools into the registry |
 | **Observability** | `observability.py`, `usage_ledger.py`, `routers/usage.py` | Per-request logging, OTel seam, per-turn token/cost capture + durable chargeback ledger. See [OBSERVABILITY.md](OBSERVABILITY.md) |
+| **Budgets** | `budgets.py`, `routers/budgets.py` | Monthly USD spend caps per user/department: current-month spend (from the ledger), warn/block status, and `enforce_budget` applied at the chat + gateway choke points. See [BUDGETS.md](BUDGETS.md) |
 | **API gateway** | `api_keys.py`, `routers/api_keys.py`, `routers/gateway.py` | Per-user API keys (SHA-256 hashed) + OpenAI-compatible `/v1/chat/completions` & `/v1/models`; usage flows through `usage_ledger`. See [API_GATEWAY.md](API_GATEWAY.md) |
-| **Routers** | `routers/*.py` | `auth, chat, conversations, providers, settings, documents, mcp, tools, files, memories, checkpoints, attachments, usage, admin_config, api_keys, gateway` |
+| **Routers** | `routers/*.py` | `auth, chat, conversations, providers, settings, documents, mcp, tools, files, memories, checkpoints, attachments, usage, admin_config, api_keys, gateway, budgets` |
 
 ### Key design decisions
 - **One unified tool surface.** Built-in tools, MCP tools, and `search_documents` all
@@ -151,6 +152,16 @@ deals with provider-specific shapes.
 - **Self-healing model setting** (`runtime_settings.py::_heal_model`): if the DB's active
   model isn't valid for the profile catalog (e.g. after a `config.yml` edit), it falls back
   to the profile's configured model so stale settings don't override config.
+- **Spend budgets enforce at the model-call choke points** (`budgets.py`). Admin-set monthly
+  USD caps (`Budget`, scoped to a user or department) are checked by `enforce_budget` in
+  *both* `routers/chat.py` and `routers/gateway.py`, so interactive chat and API-key traffic
+  are gated identically. "Spend this month" is a live, date-bounded sum over `UsageLedger`
+  (no counter to reset — the window rolls forward), so budgets reuse the chargeback ledger
+  rather than adding new accounting. Enforcement is **most-restrictive-wins** (a user's own
+  budget and their department budget both apply) and only blocks **priced** models (those in
+  `observability.pricing`); free/local models stay usable. Because cost is known only after a
+  turn finishes, it blocks the *next* turn once at/over budget rather than mid-turn. See
+  [BUDGETS.md](BUDGETS.md).
 
 ## 4. Frontend module map (`frontend/src/`)
 
@@ -162,7 +173,7 @@ deals with provider-specific shapes.
 | **Layout** | `components/layout/Header.jsx`, `Sidebar.jsx` | FH logo header, conversation list, nav |
 | **Chat** | `components/chat/*` | `Message`, `ToolCallCard`, `ArtifactViewer`, `Composer`; `pages/ChatPage.jsx` |
 | **Markdown** | `components/markdown/Markdown.jsx` | react-markdown + GFM + syntax highlight + copy |
-| **Settings** | `components/settings/*`, `documents/*`, `mcp/*`, `tools/*` | Drawer with user tabs (Model, Appearance, Documents, Memory) + admin tabs (Users, Usage & Cost, **Configuration**, Authentication, MCP, Tools) |
+| **Settings** | `components/settings/*`, `documents/*`, `mcp/*`, `tools/*` | Drawer with user tabs (Model, Appearance, Documents, Memory, API Keys) + admin tabs (Users, Usage & Cost, **Budgets**, **Configuration**, Authentication, MCP, Tools) |
 
 The frontend renders a rich turn: collapsible **tool cards** (args + results), a
 **reasoning** disclosure, inline **artifacts** (images render, files download), and
@@ -182,6 +193,9 @@ streamed markdown with highlighted, copyable code.
 - `UsageLedger` — append-only, **FK-free** per-turn token/cost rows with a snapshot of the
   billable identity (username/email/department). Deliberately survives user deletion for
   chargeback; see [OBSERVABILITY.md](OBSERVABILITY.md) / [AUTH.md](AUTH.md).
+- `Budget` — a monthly USD spend cap scoped to a user (`scope_value` = `User.id`) or a
+  department (`scope_value` = name), with `limit_usd`, `warn_pct`, and `is_active`. FK-free;
+  spend is summed live from `UsageLedger` (no stored counter). See [BUDGETS.md](BUDGETS.md).
 - `ApiKey` — per-user gateway keys: only a SHA-256 `key_hash` (unique) + non-secret
   `prefix` are stored, with `is_active`/`expires_at`/`last_used_at`. Resolves to the owning
   `User` (the billable identity); hard-deleted with the user. See [API_GATEWAY.md](API_GATEWAY.md).
@@ -222,6 +236,8 @@ Three layers, each with a clear job:
   [THEMING.md](THEMING.md).
 - **MCP servers** → no code; configure in the UI. Internals in [MCP.md](MCP.md).
 - **A new settings tab / panel** → add a tab in `components/settings/SettingsDrawer.jsx`.
+- **A spend/quota check on model calls** → add it to `budgets.py` and call it from the gate
+  in both `routers/chat.py` and `routers/gateway.py` (the two model-call choke points).
 - **Harder code-exec isolation** → implement `DockerRunner` in `sandbox/runner.py`.
 - **Bigger RAG corpus** → replace `rag/retrieve.search_chunks` with a vector index; keep
   the signature so `search_documents` is unaffected.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -29,10 +29,11 @@ regardless of provider, so the rest of the app is auth-method-agnostic.
   management** — create users, **reset passwords**, set a **department** (for chargeback),
   enable/disable, and **delete accounts**. Deleting an account **purges all of that user's
   data** (chats + workspaces, documents + files + vectors, memories, settings, **API
-  keys**) via `auth/service.delete_user_data` — the admin never reads the content, it is
-  just removed. (A deleted user's gateway keys are hard-deleted so they can never
-  authenticate again, while their incurred usage survives in the ledger; see
-  [API_GATEWAY.md](API_GATEWAY.md).)
+  keys**, and any **user-scoped spend budget**) via `auth/service.delete_user_data` — the
+  admin never reads the content, it is just removed. (A deleted user's gateway keys are
+  hard-deleted so they can never authenticate again, while their incurred usage survives in
+  the ledger; see [API_GATEWAY.md](API_GATEWAY.md). Department budgets are not tied to one
+  account and are left intact — see [BUDGETS.md](BUDGETS.md).)
 - **Admin deployment configuration** (`routers/admin_config.py`, **Settings → (Admin)
   Configuration**): admins edit a curated set of `config.yml` sections **live, without a
   restart** — provider profiles, model pricing, resilience, generation defaults, and sandbox

--- a/docs/BUDGETS.md
+++ b/docs/BUDGETS.md
@@ -1,0 +1,65 @@
+# Spend Budgets
+
+Monthly USD spend caps for **users** and **departments**, enforced against the durable
+usage ledger. When a budget's current-month spend crosses its warning threshold (default
+90%) the user sees a banner; when it reaches or exceeds the limit, **priced** models are
+blocked until the calendar month rolls over. Models with no configured price are never
+blocked.
+
+## Concepts
+
+- **Budget** — a row scoped to either a single `user` (by user id) or a `department` (by
+  name), with a `limit_usd` and a `warn_pct`. Created/managed by admins in
+  **Settings → Admin → Budgets**.
+- **Priced model** — a model that has a per-million-token entry in
+  `observability.pricing` (the same table that drives cost accounting). Only priced models
+  count toward spend and only priced models are blocked. Free/local models stay usable.
+- **Most-restrictive-wins** — a user may be covered by both their own user budget and their
+  department budget. A turn is blocked if **either** is at/over its limit; the warning fires
+  for whichever applicable budget is closest to its limit.
+- **Monthly reset** — spend is summed over the current UTC calendar month
+  (`[first-of-month, first-of-next-month)`). No stored counter to reset; it simply rolls
+  forward because the ledger query is date-bounded.
+
+## Enforcement points
+
+Spend can only be known *after* a turn completes (token cost isn't known until the model
+responds), so enforcement blocks the **next** turn once you are at/over budget — not
+mid-turn. Both model-call choke points are gated, so API-key (gateway) traffic is covered
+identically to interactive chat:
+
+- Interactive chat — `POST /api/chat` returns **HTTP 402** before the turn runs.
+- Gateway — `POST /v1/chat/completions` returns an OpenAI-shaped 402 error; `GET /v1/models`
+  annotates priced models with `phlox_blocked: true` when the caller is over budget.
+
+A single in-flight turn can overshoot the cap slightly (the turn that crosses the line is
+allowed to finish). That is acceptable for a guardrail; it is not a hard pre-authorization.
+
+## Data model
+
+`budgets` table (`app/models.py::Budget`), FK-free like the rest of the per-user model:
+
+| column        | meaning                                             |
+|---------------|-----------------------------------------------------|
+| `scope_type`  | `user` \| `department`                              |
+| `scope_value` | the user id, or the department name                 |
+| `limit_usd`   | monthly cap in USD                                  |
+| `warn_pct`    | warn threshold percent (default 90)                 |
+| `is_active`   | soft on/off without deleting                        |
+
+Unique on `(scope_type, scope_value)`.
+
+Deleting a user removes their **user-scoped** budget (it would otherwise linger as an
+orphaned config row); **department** budgets are left intact, and the departed user's past
+spend still counts toward the department for chargeback via the identity-snapshotted ledger.
+
+## API
+
+- `GET  /api/usage/budget` — the signed-in user's budget status (for the UI banner).
+- `GET  /api/admin/budgets` — admin: list budgets with current-month spend each.
+- `POST /api/admin/budgets` — admin: create.
+- `PATCH /api/admin/budgets/{id}` — admin: update limit / warn / active / scope.
+- `DELETE /api/admin/budgets/{id}` — admin: delete.
+
+Core logic lives in `app/budgets.py` (`month_bounds`, `current_month_spend`,
+`applicable_budgets`, `budget_status`, `enforce_budget`).

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -51,6 +51,11 @@ capturing tokens/cost/model **plus a snapshot of the billable identity**
   can't double-count), so programmatic usage shows up in the same chargeback view as chat.
   See [API_GATEWAY.md](API_GATEWAY.md).
 
+> **The ledger also powers spend budgets.** Monthly USD caps per user/department are
+> enforced by summing this ledger over the current month — no separate accounting. The
+> `pricing` map above doubles as the definition of a "priced" (and therefore blockable)
+> model. See [BUDGETS.md](BUDGETS.md).
+
 ## 2. Structured request logging
 
 A middleware logs one line per API request: method, path, status, duration, and the user

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,6 +100,16 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
   from Entra claims). _Implemented in:_ `usage_ledger.py`, `models.py` (`UsageLedger`,
   `User.department`), `routers/usage.py`, `auth/{service,entra}.py`, `UsagePanel.jsx`,
   `UsersPanel.jsx`. See [OBSERVABILITY.md](OBSERVABILITY.md) + [AUTH.md](AUTH.md).
+- [x] **Spend budgets.** Admin-set **monthly USD caps** per **user** or **department**, with
+  an adjustable **warn threshold** (default 90%, in-UI banner) and **hard enforcement** that
+  blocks **priced** models once a budget is reached (free models stay usable). Enforced at
+  both model-call choke points — interactive chat (HTTP 402) and the API gateway (OpenAI-shaped
+  402 + `phlox_blocked` on `/v1/models`) — so API-key traffic is gated identically. Spend is a
+  live, date-bounded sum over the `UsageLedger` (no counter to reset; rolls forward monthly);
+  enforcement is most-restrictive-wins across a user's own + their department budget.
+  _Implemented in:_ `budgets.py`, `models.py` (`Budget`), `routers/budgets.py`,
+  `routers/{chat,gateway,usage}.py`, `auth/service.py` (cleanup), `BudgetsPanel.jsx`,
+  `ChatPage.jsx` (banner). See [BUDGETS.md](BUDGETS.md).
 - [x] **Live admin configuration.** Admin-only **Configuration** panel to edit deployment
   config without a restart: provider profiles (API keys **write-only/masked**), model
   pricing, resilience, generation defaults, and sandbox **limits**. `config.yml` is the seed;
@@ -147,14 +157,17 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
 ## API gateway (OpenAI-compatible)
 
 Use Phlox programmatically as an authenticated LLM gateway, with the same per-user/department
-cost accounting as interactive chat. See [API_GATEWAY.md](API_GATEWAY.md).
+cost accounting **and spend-budget enforcement** as interactive chat (a 402 once over budget).
+See [API_GATEWAY.md](API_GATEWAY.md).
 
 - [x] **Phase 1 — raw passthrough.** Per-user API keys (SHA-256 hashed, revocable, expiring),
   OpenAI-compatible `POST /v1/chat/completions` (streaming + buffered) and `GET /v1/models`,
   exactly one model call per request, usage recorded to the `UsageLedger`.
 - [ ] **Phase 2 — agentic endpoint.** `POST /v1/agent/completions` exposing RAG + tools + MCP;
   the N model calls of one request grouped by `parent_request_id` (the ledger seam is already
-  in place). Per-key budgets / rate-limiting are a candidate follow-up here.
+  in place). Per-user/department spend budgets already apply to gateway calls (see
+  [BUDGETS.md](BUDGETS.md)); finer-grained **per-key** budgets / rate-limiting are a candidate
+  follow-up here.
 
 ## Tier 5 — Sensitive-data deployment (PHI)
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -87,6 +87,13 @@ export const api = {
     return req('GET', `/api/usage/by-user${q ? `?${q}` : ''}`)
   },
 
+  // budgets (monthly spend caps): self status + admin CRUD
+  budgetStatus: () => req('GET', '/api/usage/budget'),
+  listBudgets: () => req('GET', '/api/admin/budgets'),
+  createBudget: (body) => req('POST', '/api/admin/budgets', body),
+  updateBudget: (id, body) => req('PATCH', `/api/admin/budgets/${id}`, body),
+  deleteBudget: (id) => req('DELETE', `/api/admin/budgets/${id}`),
+
   // api keys (gateway access)
   listApiKeys: () => req('GET', '/api/api-keys'),
   createApiKey: (body) => req('POST', '/api/api-keys', body || {}),

--- a/frontend/src/api/sse.js
+++ b/frontend/src/api/sse.js
@@ -14,7 +14,18 @@ export function streamChat(payload, onEvent, onDone, onError, path = '/api/chat'
         signal: controller.signal,
       })
       if (!res.ok || !res.body) {
-        throw new Error(`Chat failed: ${res.status}`)
+        // Surface the server's error detail (e.g. a 402 budget rejection) instead of a
+        // bare status code, so the UI can show a meaningful message.
+        let detail = ''
+        try {
+          const data = await res.clone().json()
+          detail = data?.detail || data?.error?.message || ''
+        } catch {
+          /* non-JSON body */
+        }
+        const err = new Error(detail || `Chat failed: ${res.status}`)
+        err.status = res.status
+        throw err
       }
       const reader = res.body.getReader()
       const decoder = new TextDecoder()

--- a/frontend/src/components/settings/BudgetsPanel.jsx
+++ b/frontend/src/components/settings/BudgetsPanel.jsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Wallet, Trash2, Plus, Loader2, Building2, User as UserIcon } from 'lucide-react'
+import { api } from '../../api/client'
+
+const fmtCost = (n) =>
+  (n || 0).toLocaleString(undefined, {
+    style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2,
+  })
+
+// Bar colour tracks headroom: green under warn, amber at/over warn, red at/over limit.
+function barColor(pct, warnPct) {
+  if (pct >= 100) return 'var(--color-danger, #dc2626)'
+  if (pct >= (warnPct || 90)) return '#d97706'
+  return 'var(--color-accent)'
+}
+
+export default function BudgetsPanel() {
+  const [budgets, setBudgets] = useState([])
+  const [users, setUsers] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [form, setForm] = useState({ scope_type: 'department', scope_value: '', limit_usd: '', warn_pct: 90 })
+  const [busy, setBusy] = useState(false)
+
+  const load = () =>
+    api.listBudgets()
+      .then((r) => setBudgets(r.budgets || []))
+      .catch((e) => setError(String(e).replace('Error: ', '')))
+      .finally(() => setLoading(false))
+
+  useEffect(() => {
+    load()
+    api.listUsers().then(setUsers).catch(() => setUsers([]))
+  }, [])
+
+  // Known departments (from users) power the department dropdown.
+  const departments = useMemo(
+    () => [...new Set(users.map((u) => u.department).filter(Boolean))].sort(),
+    [users],
+  )
+
+  const add = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await api.createBudget({
+        scope_type: form.scope_type,
+        scope_value: form.scope_value.trim(),
+        limit_usd: parseFloat(form.limit_usd),
+        warn_pct: parseInt(form.warn_pct, 10),
+      })
+      setForm({ scope_type: form.scope_type, scope_value: '', limit_usd: '', warn_pct: 90 })
+      await load()
+    } catch (e) {
+      setError(String(e).replace('Error: ', ''))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const patch = (b, body) => api.updateBudget(b.id, body).then(load)
+  const remove = (b) => {
+    if (confirm(`Delete the ${b.scope_type} budget for "${b.scope_label}"?`))
+      api.deleteBudget(b.id).then(load)
+  }
+
+  const valid =
+    form.scope_value.trim() && form.limit_usd !== '' && parseFloat(form.limit_usd) >= 0
+
+  return (
+    <div>
+      <h3 className="mb-1 flex items-center gap-2 text-sm font-semibold text-content">
+        <Wallet size={15} className="text-accent" /> Spend Budgets
+      </h3>
+      <p className="mb-4 text-xs text-muted">
+        Cap monthly spend per <b>user</b> or <b>department</b>. Users see a warning when they
+        cross the warn threshold, and <b>priced</b> models are blocked once a budget is
+        reached — models without an assigned cost stay available. Spend is summed from the
+        usage ledger over the current month and resets automatically. Most-restrictive budget
+        wins when both a user and department budget apply.
+      </p>
+
+      {error && <div className="mb-3 rounded bg-red-50 px-3 py-1.5 text-xs text-red-700">{error}</div>}
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-muted"><Loader2 size={14} className="animate-spin" /> Loading…</div>
+      ) : (
+        <div className="mb-5 space-y-2">
+          {budgets.length === 0 && (
+            <div className="rounded-lg border border-dashed border-border px-3 py-4 text-center text-xs text-muted">
+              No budgets yet. Add one below.
+            </div>
+          )}
+          {budgets.map((b) => (
+            <div key={b.id} className="rounded-lg border border-border bg-surface px-3 py-2">
+              <div className="flex items-center gap-3">
+                {b.scope_type === 'department'
+                  ? <Building2 size={16} className="text-hutch-purple" />
+                  : <UserIcon size={16} className="text-muted" />}
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm text-content">
+                    {b.scope_label}
+                    <span className="ml-1 text-[10px] text-muted">({b.scope_type})</span>
+                    {!b.is_active && <span className="ml-1 text-[10px] text-muted">· paused</span>}
+                  </div>
+                  <div className="text-[11px] text-muted">
+                    {fmtCost(b.spent_usd)} of {fmtCost(b.limit_usd)} this month · {b.pct}%
+                    {b.warn_pct ? ` · warn ${b.warn_pct}%` : ''}
+                  </div>
+                </div>
+                <button onClick={() => patch(b, { is_active: !b.is_active })}
+                  className="text-[11px] text-muted hover:text-accent">
+                  {b.is_active ? 'pause' : 'resume'}
+                </button>
+                <button onClick={() => remove(b)} className="rounded p-1 text-muted hover:text-red-600" title="Delete budget">
+                  <Trash2 size={14} />
+                </button>
+              </div>
+              {/* spend bar */}
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-surface-3">
+                <div className="h-full rounded-full transition-all"
+                  style={{ width: `${Math.min(b.pct, 100)}%`, background: barColor(b.pct, b.warn_pct) }} />
+              </div>
+              {/* inline editors */}
+              <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-border pt-2 text-[11px] text-muted">
+                <label className="flex items-center gap-1">
+                  Limit $
+                  <input type="number" min="0" step="0.5" defaultValue={b.limit_usd}
+                    onBlur={(e) => { const v = parseFloat(e.target.value); if (v >= 0 && v !== b.limit_usd) patch(b, { limit_usd: v }) }}
+                    className="w-20 rounded border-border bg-surface-2 py-0.5 text-xs text-content focus:border-accent focus:ring-accent" />
+                </label>
+                <label className="flex items-center gap-1">
+                  Warn %
+                  <input type="number" min="0" max="100" defaultValue={b.warn_pct}
+                    onBlur={(e) => { const v = parseInt(e.target.value, 10); if (v >= 0 && v <= 100 && v !== b.warn_pct) patch(b, { warn_pct: v }) }}
+                    className="w-16 rounded border-border bg-surface-2 py-0.5 text-xs text-content focus:border-accent focus:ring-accent" />
+                </label>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-border bg-surface-2 p-3">
+        <div className="mb-2 text-sm font-medium text-content">Add a budget</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select value={form.scope_type}
+            onChange={(e) => setForm({ ...form, scope_type: e.target.value, scope_value: '' })}
+            className="rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent">
+            <option value="department">Department</option>
+            <option value="user">User</option>
+          </select>
+
+          {form.scope_type === 'user' ? (
+            <select value={form.scope_value} onChange={(e) => setForm({ ...form, scope_value: e.target.value })}
+              className="flex-1 rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent">
+              <option value="">Select user…</option>
+              {users.map((u) => (
+                <option key={u.id} value={u.id}>{u.display_name || u.username}</option>
+              ))}
+            </select>
+          ) : (
+            <input list="known-departments" placeholder="Department name"
+              value={form.scope_value} onChange={(e) => setForm({ ...form, scope_value: e.target.value })}
+              className="flex-1 rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent" />
+          )}
+          <datalist id="known-departments">
+            {departments.map((d) => <option key={d} value={d} />)}
+          </datalist>
+
+          <label className="flex items-center gap-1 text-xs text-muted">
+            $/mo
+            <input type="number" min="0" step="0.5" placeholder="5.00" value={form.limit_usd}
+              onChange={(e) => setForm({ ...form, limit_usd: e.target.value })}
+              className="w-24 rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent" />
+          </label>
+          <label className="flex items-center gap-1 text-xs text-muted">
+            warn %
+            <input type="number" min="0" max="100" value={form.warn_pct}
+              onChange={(e) => setForm({ ...form, warn_pct: e.target.value })}
+              className="w-16 rounded-lg border-border bg-surface text-sm text-content focus:border-accent focus:ring-accent" />
+          </label>
+          <button onClick={add} disabled={busy || !valid}
+            className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-sm text-accent-fg hover:opacity-90 disabled:opacity-50">
+            {busy ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />} Add
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/SettingsDrawer.jsx
+++ b/frontend/src/components/settings/SettingsDrawer.jsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal } from 'lucide-react'
+import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal, Wallet } from 'lucide-react'
 import ProviderSettings from './ProviderSettings'
 import ThemeSwitcher from './ThemeSwitcher'
 import MemoryPanel from './MemoryPanel'
 import UsersPanel from './UsersPanel'
 import UsagePanel from './UsagePanel'
 import ConfigPanel from './ConfigPanel'
+import BudgetsPanel from './BudgetsPanel'
 import AuthSettingsPanel from './AuthSettingsPanel'
 import ApiKeysPanel from './ApiKeysPanel'
 import DocumentsPanel from '../documents/DocumentsPanel'
@@ -24,6 +25,7 @@ const USER_TABS = [
 const ADMIN_TABS = [
   { id: 'users', label: 'Users', icon: Users },
   { id: 'usage', label: 'Usage & Cost', icon: BarChart3 },
+  { id: 'budgets', label: 'Budgets', icon: Wallet },
   { id: 'config', label: 'Configuration', icon: SlidersHorizontal },
   { id: 'auth', label: 'Authentication', icon: KeyRound },
   { id: 'mcp', label: 'MCP Servers', icon: Server },
@@ -187,6 +189,7 @@ export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
             {isAdmin && tab === 'tools' && <ToolManager />}
             {isAdmin && tab === 'users' && <UsersPanel />}
             {isAdmin && tab === 'usage' && <UsagePanel />}
+            {isAdmin && tab === 'budgets' && <BudgetsPanel />}
             {isAdmin && tab === 'config' && <ConfigPanel />}
             {isAdmin && tab === 'auth' && <AuthSettingsPanel />}
           </div>

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,8 +1,47 @@
 import { useEffect, useRef } from 'react'
+import { AlertTriangle, Ban } from 'lucide-react'
 import Message from '../components/chat/Message'
 import Composer from '../components/chat/Composer'
 import ApprovalPrompt from '../components/chat/ApprovalPrompt'
 import { useStore } from '../store/useStore'
+
+const fmtUsd = (n) =>
+  (n || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+
+// Banner shown when the signed-in user is over (blocked) or near (warn) a monthly budget.
+function BudgetBanner() {
+  const budget = useStore((s) => s.budget)
+  if (!budget || (!budget.blocked && !budget.warn)) return null
+  const w = budget.worst || {}
+  const where = w.scope_type === 'department' ? 'Your department' : 'You'
+  const blocked = budget.blocked
+  return (
+    <div
+      className={`mx-auto mb-2 flex max-w-3xl items-start gap-2 rounded-lg border px-4 py-2 text-sm ${
+        blocked
+          ? 'border-red-300 bg-red-50 text-red-700'
+          : 'border-amber-300 bg-amber-50 text-amber-800'
+      }`}
+      role="status"
+    >
+      {blocked ? <Ban size={16} className="mt-0.5 shrink-0" /> : <AlertTriangle size={16} className="mt-0.5 shrink-0" />}
+      <div>
+        {blocked ? (
+          <>
+            <b>Monthly budget reached.</b> {where} {where === 'You' ? 'have' : 'has'} used{' '}
+            {fmtUsd(w.spent_usd)} of the {fmtUsd(w.limit_usd)} budget. Models with an assigned
+            cost are paused until the budget resets next month; free models still work.
+          </>
+        ) : (
+          <>
+            <b>Approaching budget limit.</b> {where} {where === 'You' ? 'have' : 'has'} used{' '}
+            {fmtUsd(w.spent_usd)} of {fmtUsd(w.limit_usd)} ({w.pct}%) this month.
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
 
 const SUGGESTIONS = [
   'Write a Python script to plot a sine wave and run it',
@@ -125,6 +164,9 @@ export default function ChatPage() {
             <div ref={endRef} />
           </div>
         )}
+      </div>
+      <div className="px-4 pt-2">
+        <BudgetBanner />
       </div>
       <Composer />
     </div>

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -23,6 +23,7 @@ export const useStore = create((set, get) => ({
   error: null,
   queued: null, // a follow-up message queued while streaming {text, images, autoApprove, webSearch}
   lastUsage: null, // {input, output, total} token usage from the last model response
+  budget: null, // monthly budget status for the signed-in user (or null when none applies)
 
   // -- auth ----------------------------------------------------------------
   authConfig: null, // {enabled, allow_registration, entra_enabled}
@@ -57,7 +58,20 @@ export const useStore = create((set, get) => ({
   },
 
   async loadApp() {
-    await Promise.all([get().loadConversations(), get().loadSettings(), get().loadProviders()])
+    await Promise.all([
+      get().loadConversations(), get().loadSettings(), get().loadProviders(), get().loadBudget(),
+    ])
+  },
+
+  // Monthly budget status (drives the chat warning/block banner). Refreshed after each
+  // turn since spend changes. Null'd out if the request fails or no budget applies.
+  async loadBudget() {
+    try {
+      const b = await api.budgetStatus()
+      set({ budget: b && b.budgets && b.budgets.length ? b : null })
+    } catch {
+      set({ budget: null })
+    }
   },
 
   async login(username, password) {
@@ -199,7 +213,11 @@ export const useStore = create((set, get) => ({
       payload,
       (ev) => get()._onEvent(ev),
       () => get()._finalize(),
-      (err) => set({ error: String(err), streaming: false, live: null }),
+      (err) => {
+        set({ error: String(err).replace(/^Error:\s*/, ''), streaming: false, live: null })
+        // A 402 budget rejection means spend/limit state may have changed — refresh banner.
+        if (err?.status === 402) get().loadBudget()
+      },
     )
     set({ abortFn })
   },
@@ -311,6 +329,8 @@ export const useStore = create((set, get) => ({
       set({ live: null })
     }
     get().loadConversations()
+    // Spend changed this turn — refresh the budget banner.
+    get().loadBudget()
 
     // Send any follow-up the user queued while this turn was streaming.
     const q = get().queued


### PR DESCRIPTION
Closes #14

## Summary

Adds **spend budgets** — admin-set monthly USD caps scoped to a **user** or a **department**. Users get a warning banner as they approach the cap, and **priced** models are blocked once the cap is reached (free/unpriced models stay usable). Spend is measured over the current calendar month and resets automatically.

Enforcement is applied at **both** model-call entry points — interactive chat and the OpenAI-compatible API gateway — so a budget can't be bypassed via API keys.

## Design decisions

- **Reuses the existing ledger.** "Spend this month" is a date-bounded sum over the durable `UsageLedger` (the same metadata that powers chargeback). No new counter to maintain or reset — the month window just rolls forward.
- **Priced = blockable.** A model is subject to budgets only if it has an `observability.pricing` entry. Free/local models are never blocked.
- **Most-restrictive-wins.** When a user budget and their department budget both apply, a turn is blocked if *either* is over; the warning fires for whichever is closest to its limit.
- **Next-turn enforcement.** Token cost is only known after a turn completes, so the gate blocks the *next* turn once at/over budget rather than cutting off mid-turn. A single turn can overshoot a small cap slightly — acceptable for a guardrail, not a hard pre-authorization. *(Raised as an open question in #14; this is the chosen tradeoff.)*

## Changes

**Backend**
- New `Budget` model (`models.py`) — scope (user/department), `limit_usd`, `warn_pct`, `is_active`; unique per scope. Created via `create_all` (no migration needed).
- New `app/budgets.py` — `current_month_spend`, `budget_status`, `enforce_budget` (raises HTTP 402).
- Gate wired into `routers/chat.py` (402 before the turn) and `routers/gateway.py` (OpenAI-shaped `insufficient_quota` 402 + `phlox_blocked` flag on `/v1/models`).
- `GET /api/usage/budget` (current-user status) + admin CRUD at `/api/admin/budgets` (`routers/budgets.py`).
- `delete_user_data` now removes a deleted user's user-scoped budget (department budgets left intact).

**Frontend**
- Admin **Budgets** settings tab (`BudgetsPanel.jsx`) — create/edit/pause/delete with live spend bars.
- Chat **warning/block banner** (`ChatPage.jsx`), budget status in the store, and readable 402 surfacing (`sse.js`).

**Docs**
- New `docs/BUDGETS.md`; updates to README, ARCHITECTURE, OBSERVABILITY, API_GATEWAY, AUTH, and ROADMAP.

## Testing

- New `backend/tests/test_budgets.py` (8 tests): month-window math, warn→block transitions, priced-vs-free gating, chat 402, department attribution, admin CRUD, and user-deletion cleanup.
- Full backend suite green (50 tests); frontend builds clean.

## Acceptance criteria (from #14)

- [x] Admins can create/edit/delete budgets scoped to a user or department (limit + warn threshold)
- [x] Users see a warning banner at the configurable threshold
- [x] Priced models blocked once a budget is reached; free models remain available
- [x] Enforcement applies to both interactive chat and the API gateway
- [x] Spend resets at the start of each month
- [x] Documented in README and docs