### PR TITLE
first-class remote sandbox runners + AgentCore Code Interpreter backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ models).
 - ⚙️ **Live admin configuration** — edit provider profiles (keys write-only), model
   pricing, resilience, generation defaults, and sandbox limits from an admin-only
   **Configuration** panel, applied without a server restart. `config.yml` remains the seed.
-- 📦 **Container sandbox** — run code in an isolated **Podman/Docker** container with
-  resource limits + network isolation. See [docs/SANDBOX.md](docs/SANDBOX.md).
+- 📦 **Container / remote sandbox** — run code in an isolated **Podman/Docker** container
+  (resource limits + network isolation), or **off-host** in an AWS Bedrock AgentCore Code
+  Interpreter microVM (kernel-level isolation). See [docs/SANDBOX.md](docs/SANDBOX.md).
 - 🎨 **Theming** — Phlox Dark (default) + Phlox Light/Light/Dark/Fred Hutch/Hutch
   Night/Sandstone/**Terminal** (CRT phosphor-green), instant switching. See
   [docs/THEMING.md](docs/THEMING.md).
@@ -75,7 +76,7 @@ models).
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Production deployment on Linux (Ubuntu/RHEL) under **systemd** |
 | [docs/DOCKER.md](docs/DOCKER.md) | Running Phlox in a container (**Docker or Podman**) |
 | [docs/AUTH.md](docs/AUTH.md) | Local accounts, roles, multi-user isolation, **Entra ID SSO** setup |
-| [docs/SANDBOX.md](docs/SANDBOX.md) | Local vs **Podman/Docker container** code-execution sandbox |
+| [docs/SANDBOX.md](docs/SANDBOX.md) | Code-execution sandbox: **local** vs **Podman/Docker container** vs **AWS AgentCore** (off-host microVM) |
 | [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) | Token usage/cost, structured logs, OpenTelemetry tracing |
 | [docs/BUDGETS.md](docs/BUDGETS.md) | Monthly spend budgets per user/department: warnings + enforcement |
 | [docs/API_GATEWAY.md](docs/API_GATEWAY.md) | OpenAI-compatible API gateway: API keys + `/v1/*` endpoints |
@@ -179,7 +180,9 @@ access — see [docs/AUTH.md](docs/AUTH.md). To run single-user with no login, s
 
 By default code runs in a **local subprocess** (fast, trusts the host). For isolation, set
 `sandbox.runner: container` to run each execution in an ephemeral **Podman/Docker**
-container with CPU/memory/PID limits and network isolation. For data-analysis workloads you
+container with CPU/memory/PID limits and network isolation, or `sandbox.runner: agentcore`
+to run it **off-host** in an AWS Bedrock AgentCore Code Interpreter microVM (Firecracker,
+kernel-level isolation — no local Docker needed). For data-analysis workloads you
 can optionally build the **batteries-included images** (numpy/pandas/matplotlib/… preinstalled)
 so the agent doesn't pip-install packages on every run — see [docs/SANDBOX.md](docs/SANDBOX.md).
 
@@ -229,7 +232,8 @@ cd backend && uv run python -m evals.run_evals
   `PHLOX_JWT_SECRET`) before any shared use. Data is isolated per user; admin features
   are role-gated.
 - **Sandbox:** the local runner trusts the host (fine for single-user/local). For
-  untrusted/multi-user execution use `sandbox.runner: container` ([docs/SANDBOX.md](docs/SANDBOX.md)).
+  untrusted/multi-user execution use `sandbox.runner: container` (on-host, isolated) or
+  `sandbox.runner: agentcore` (off-host AWS microVM) ([docs/SANDBOX.md](docs/SANDBOX.md)).
 - Mutating/execution tools default to the **`ask`** permission policy; "Agent mode"
   auto-approves for a turn.
 - **Sensitive data (PHI):** Postgres, audit logging, secrets management, and data

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -144,12 +144,12 @@ def get_web_search_config() -> dict[str, Any]:
 
 
 def get_sandbox_config() -> dict[str, Any]:
-    """Code/shell execution sandbox config. ``runner`` is ``local`` or ``container``.
+    """Code/shell execution sandbox config. ``runner`` is ``local``, ``container``, or ``agentcore``.
 
     Admin-editable: the container **limits** (memory/cpus/pids_limit/network/images/engine)
     overlay over the file. The ``runner`` *type* is deliberately **not** overridable here —
-    flipping isolation (local <-> container) at runtime would be a security surprise, so it
-    stays file-only.
+    flipping isolation (local <-> container <-> agentcore) at runtime would be a security
+    surprise, so it stays file-only. The ``agentcore`` settings are likewise file-only.
     """
     from app import app_config
 
@@ -166,6 +166,13 @@ def get_sandbox_config() -> dict[str, Any]:
     container.setdefault("pids_limit", 256)
     container.setdefault("network", "none")  # none | bridge
     cfg["container"] = container
+
+    # AWS Bedrock AgentCore Code Interpreter (remote, off-host microVM). Only consulted
+    # when runner=agentcore; defaults mirror the container block's file-only treatment.
+    ac = dict(cfg.get("agentcore", {}) or {})
+    ac.setdefault("identifier", "aws.codeinterpreter.v1")  # built-in Code Interpreter
+    ac.setdefault("session_timeout_seconds", 900)
+    cfg["agentcore"] = ac
     return cfg
 
 

--- a/backend/app/routers/admin_config.py
+++ b/backend/app/routers/admin_config.py
@@ -10,8 +10,8 @@ Security:
 - Provider **secrets are never returned** — GET strips them and reports only a
   ``<field>_set`` boolean. PUT preserves the existing secret when the field is left blank,
   so editing a profile doesn't require re-entering its key.
-- The sandbox **runner type** (local vs container) is read-only here — flipping isolation at
-  runtime is unsafe, so it stays file-only.
+- The sandbox **runner type** (local / container / agentcore) is read-only here — flipping
+  isolation at runtime is unsafe, so it stays file-only.
 """
 from __future__ import annotations
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -102,6 +102,15 @@ def delete_conversation(
     db.delete(conv)
     db.commit()
     ws = WORKSPACES_DIR / conversation_id
+    # Tear down any per-conversation remote sandbox session before removing the local
+    # workspace. No-op for the local/container runners; the remote runner uses this to
+    # release its session deterministically (keyed by the workspace dir name).
+    try:
+        from app.sandbox.runner import get_runner
+
+        get_runner().close_session(ws)
+    except Exception:  # noqa: BLE001
+        pass
     if ws.exists():
         shutil.rmtree(ws, ignore_errors=True)
     return {"deleted": conversation_id}

--- a/backend/app/sandbox/runner.py
+++ b/backend/app/sandbox/runner.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -57,6 +58,17 @@ class SandboxRunner(ABC):
 
     @abstractmethod
     def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult: ...
+
+    def close_session(self, workdir: Path) -> None:
+        """Tear down any per-conversation remote session for this workspace.
+
+        A concrete no-op so existing runners are unchanged: ``local`` and ``container``
+        hold no session and inherit this. Remote runners that open a per-workspace
+        session (e.g. the AgentCore runner) override it to release the session
+        deterministically when a conversation is deleted — no leaked sessions, no
+        TTL-reaper hack.
+        """
+        return None
 
 
 def snapshot_dir(workdir: Path) -> dict[str, float]:
@@ -259,21 +271,305 @@ class ContainerRunner(SandboxRunner):
         return ExecResult(stdout="", stderr=f"Unsupported language: {language}", exit_code=2)
 
 
+# ---------------------------------------------------------------------------
+# Remote sandbox (AWS Bedrock AgentCore Code Interpreter)
+# ---------------------------------------------------------------------------
+class AgentCoreCodeInterpreterRunner(SandboxRunner):
+    """Run code/commands in an AWS Bedrock AgentCore Code Interpreter microVM.
+
+    Unlike the local/container runners, agent-generated code runs **off-host** with
+    kernel-level (Firecracker microVM) isolation — a real security upgrade for a
+    hosted/multi-user Phlox, since untrusted code never touches the Phlox host.
+
+    One Code Interpreter session is opened per conversation workspace (keyed by
+    ``workdir.name``) and reused across calls. The **local workspace stays
+    authoritative**: before each run the local files are synced *in*, and after each
+    run files in the session are synced *out* into the local dir — so all of Phlox's
+    local FS tools (read/write/edit/glob/grep) and mtime-based artifact detection keep
+    working untouched. ``close_session()`` tears the session down deterministically when
+    the conversation is deleted. Any AWS error falls back to the local runner so a
+    misconfiguration degrades gracefully instead of breaking the turn.
+    """
+
+    def __init__(self, config: dict):
+        self.cfg = config or {}
+        self.identifier = self.cfg.get("identifier", "aws.codeinterpreter.v1")
+        self.region = self.cfg.get("region")
+        self.profile = self.cfg.get("profile")
+        self.session_timeout = int(self.cfg.get("session_timeout_seconds", 900))
+        # Skip syncing very large files in/out to bound per-call cost (full-sync is O(workspace)).
+        self.max_sync_bytes = int(self.cfg.get("max_sync_file_bytes", 5_000_000))
+        # Sync produced files back into the local workspace after each run (so the local
+        # FS tools + artifact detection see them). Can be disabled for execute-only use.
+        self.sync_back = bool(self.cfg.get("sync_back", True))
+        self._client = None
+        self._sessions: dict[str, str] = {}     # workdir.name -> sessionId
+        self._lock = threading.Lock()
+        self._fallback = LocalSubprocessRunner()
+
+    # -- AWS client / session lifecycle -------------------------------------
+    def _c(self):
+        if self._client is None:
+            import boto3  # already a Phlox dependency (used by the Bedrock provider)
+
+            if self.profile:
+                self._client = boto3.Session(
+                    profile_name=self.profile, region_name=self.region
+                ).client("bedrock-agentcore")
+            else:
+                self._client = boto3.client("bedrock-agentcore", region_name=self.region)
+        return self._client
+
+    def _session_for(self, workdir: Path) -> str:
+        key = workdir.name
+        with self._lock:
+            sid = self._sessions.get(key)
+            if sid:
+                return sid
+        resp = self._c().start_code_interpreter_session(
+            codeInterpreterIdentifier=self.identifier,
+            name=f"phlox-{key}"[:50],
+            sessionTimeoutSeconds=self.session_timeout,
+        )
+        sid = resp["sessionId"]
+        with self._lock:
+            # Another thread may have created one concurrently; keep the first and
+            # drop ours so we don't leak a session.
+            existing = self._sessions.get(key)
+            if existing:
+                other = sid
+            else:
+                self._sessions[key] = sid
+                other = None
+        if other:
+            self._stop(other)
+            return existing
+        return sid
+
+    def _stop(self, sid: str) -> None:
+        try:
+            self._c().stop_code_interpreter_session(
+                codeInterpreterIdentifier=self.identifier, sessionId=sid
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("AgentCore stop_session failed: %s", exc)
+
+    def close_session(self, workdir: Path) -> None:
+        with self._lock:
+            sid = self._sessions.pop(workdir.name, None)
+        if sid:
+            self._stop(sid)
+
+    # -- invoke + event-stream handling -------------------------------------
+    def _invoke(self, sid: str, name: str, arguments: dict):
+        return self._c().invoke_code_interpreter(
+            codeInterpreterIdentifier=self.identifier, sessionId=sid, name=name, arguments=arguments
+        )
+
+    @staticmethod
+    def _consume(resp) -> dict:
+        """Drain an ``invoke_code_interpreter`` response into one result dict.
+
+        The response carries an event stream under ``stream``; each ``result`` event has
+        ``result.structuredContent`` (clean ``stdout``/``stderr``/``exitCode`` for
+        execute* tools) and ``result.content[]`` (MCP-style ``text``/``resource`` blocks,
+        used by the file tools). Shapes are from the ``bedrock-agentcore`` botocore model.
+        """
+        out = {"stdout": "", "stderr": "", "exit_code": 0, "is_error": False,
+               "content": [], "text": ""}
+        text_parts: list[str] = []
+        for event in resp.get("stream", []):
+            result = event.get("result")
+            if not result:
+                continue
+            if result.get("isError"):
+                out["is_error"] = True
+            sc = result.get("structuredContent") or {}
+            out["stdout"] += sc.get("stdout") or ""
+            out["stderr"] += sc.get("stderr") or ""
+            if sc.get("exitCode") is not None:
+                try:
+                    out["exit_code"] = int(sc["exitCode"])
+                except (TypeError, ValueError):
+                    pass
+            for block in result.get("content", []) or []:
+                out["content"].append(block)
+                if block.get("type") == "text" and block.get("text"):
+                    text_parts.append(block["text"])
+        out["text"] = "\n".join(text_parts)
+        return out
+
+    # -- local <-> session file sync ----------------------------------------
+    def _sync_in(self, sid: str, workdir: Path) -> None:
+        files: list[dict] = []
+        for p in workdir.rglob("*"):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(workdir)
+            if any(part in _IGNORE_DIRS for part in rel.parts):
+                continue
+            try:
+                if p.stat().st_size > self.max_sync_bytes:
+                    continue
+            except OSError:
+                continue
+            entry: dict = {"path": str(rel)}
+            try:
+                entry["text"] = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                try:
+                    entry["blob"] = p.read_bytes()   # binary file -> blob (model supports it)
+                except OSError:
+                    continue
+            files.append(entry)
+        if files:
+            self._invoke(sid, "writeFiles", {"content": files})
+
+    def _sync_out(self, sid: str, workdir: Path) -> None:
+        if not self.sync_back:
+            return
+        try:
+            listing = self._consume(self._invoke(sid, "listFiles", {"directoryPath": "."}))
+            paths = self._listing_paths(listing)
+            if not paths:
+                return
+            read = self._consume(self._invoke(sid, "readFiles", {"paths": paths}))
+            self._write_back(read["content"], workdir)
+        except Exception as exc:  # noqa: BLE001
+            # Best-effort: the local dir stays authoritative, so a sync-out miss never
+            # breaks the run — it just means produced files may not appear locally.
+            logger.warning("AgentCore sync_out failed: %s", exc)
+
+    @staticmethod
+    def _safe_rel(path: str) -> str | None:
+        """Return a workspace-relative path, or None if it escapes/looks unsafe."""
+        if not path:
+            return None
+        path = path.lstrip("./")
+        if not path or path.startswith("/") or ".." in Path(path).parts:
+            return None
+        return path
+
+    def _listing_paths(self, listing: dict) -> list[str]:
+        """Best-effort parse of ``listFiles`` output into relative file paths.
+
+        listFiles surfaces entries either as ``resource`` content blocks (with a ``uri``)
+        or as a text block (newline- or JSON-listed). We accept whichever appears and skip
+        anything that doesn't look like a safe relative path.
+        """
+        paths: list[str] = []
+        for block in listing.get("content", []):
+            if block.get("type") in ("resource", "resource_link"):
+                uri = block.get("uri") or (block.get("resource") or {}).get("uri") or block.get("name")
+                rel = self._safe_rel(str(uri)) if uri else None
+                if rel:
+                    paths.append(rel)
+            elif block.get("type") == "text" and block.get("text"):
+                for line in block["text"].splitlines():
+                    rel = self._safe_rel(line.strip().strip('",[]'))
+                    if rel:
+                        paths.append(rel)
+        # De-dup, preserve order.
+        seen: set[str] = set()
+        return [p for p in paths if not (p in seen or seen.add(p))]
+
+    def _write_back(self, content: list[dict], workdir: Path) -> None:
+        """Write ``readFiles`` content blocks back into the local workspace."""
+        for block in content:
+            res = block.get("resource") if block.get("type") == "resource" else None
+            uri = (res or {}).get("uri") or block.get("uri") or block.get("name")
+            rel = self._safe_rel(str(uri)) if uri else None
+            if not rel:
+                continue
+            dest = workdir / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            text = (res or {}).get("text", block.get("text"))
+            blob = (res or {}).get("blob", block.get("data"))
+            try:
+                if text is not None:
+                    dest.write_text(text, encoding="utf-8")
+                elif blob is not None:
+                    dest.write_bytes(blob if isinstance(blob, (bytes, bytearray)) else bytes(blob))
+            except OSError as exc:
+                logger.warning("AgentCore write_back %s failed: %s", rel, exc)
+
+    # -- SandboxRunner interface --------------------------------------------
+    def run_command(self, argv: list[str], workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+        # Normalize host shell wrappers (cmd /c, /bin/sh -c) to a single command string.
+        if len(argv) >= 3 and argv[0] in ("cmd", "/bin/sh", "sh") and argv[1] in ("/c", "-c"):
+            command = argv[2]
+        else:
+            command = " ".join(argv)
+        return self._run(
+            lambda sid: self._invoke(sid, "executeCommand", {"command": command}),
+            workdir,
+            lambda: self._fallback.run_command(argv, workdir, timeout),
+        )
+
+    def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+        if language == "python":
+            lang = "python"
+        elif language in ("node", "javascript"):
+            lang = "javascript"   # AgentCore executeCode language token for Node
+        elif language == "typescript":
+            lang = "typescript"
+        else:
+            return ExecResult(stdout="", stderr=f"Unsupported language: {language}", exit_code=2)
+        return self._run(
+            lambda sid: self._invoke(sid, "executeCode", {"language": lang, "code": code}),
+            workdir,
+            lambda: self._fallback.run_code(code, language, workdir, timeout),
+        )
+
+    def _run(self, do_invoke, workdir: Path, fallback) -> ExecResult:
+        workdir.mkdir(parents=True, exist_ok=True)
+        start = time.monotonic()
+        try:
+            sid = self._session_for(workdir)
+            before = snapshot_dir(workdir)
+            self._sync_in(sid, workdir)
+            res = self._consume(do_invoke(sid))
+            self._sync_out(sid, workdir)
+            exit_code = res["exit_code"]
+            # isError without a non-zero code still means failure; surface it so tools'
+            # `is_error = exit_code != 0` is correct.
+            if res["is_error"] and exit_code == 0:
+                exit_code = 1
+            stdout = res["stdout"] or res["text"]
+            return ExecResult(
+                stdout=_truncate(stdout),
+                stderr=_truncate(res["stderr"]),
+                exit_code=exit_code,
+                duration_s=round(time.monotonic() - start, 3),
+                artifacts=collect_artifacts(workdir, before),
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("AgentCore runner failed (%s); falling back to local", e)
+            return fallback()
+
+
 _runner: SandboxRunner | None = None
 
 
 def get_runner() -> SandboxRunner:
-    """Return the process-wide sandbox runner, selected by config (local | container)."""
+    """Return the process-wide sandbox runner, selected by config (local | container | agentcore)."""
     global _runner
     if _runner is None:
         from app.config import get_sandbox_config
 
         cfg = get_sandbox_config()
-        if cfg.get("runner") == "container":
+        runner_type = cfg.get("runner")
+        if runner_type == "container":
             try:
                 _runner = ContainerRunner(cfg["container"])
             except Exception as e:  # noqa: BLE001
                 logger.warning("Container runner unavailable (%s); falling back to local", e)
+                _runner = LocalSubprocessRunner()
+        elif runner_type == "agentcore":
+            try:
+                _runner = AgentCoreCodeInterpreterRunner(cfg.get("agentcore", {}))
+            except Exception as e:  # noqa: BLE001
+                logger.warning("AgentCore runner unavailable (%s); falling back to local", e)
                 _runner = LocalSubprocessRunner()
         else:
             _runner = LocalSubprocessRunner()

--- a/backend/app/sandbox/runner.py
+++ b/backend/app/sandbox/runner.py
@@ -274,6 +274,19 @@ class ContainerRunner(SandboxRunner):
 # ---------------------------------------------------------------------------
 # Remote sandbox (AWS Bedrock AgentCore Code Interpreter)
 # ---------------------------------------------------------------------------
+# Bounds for syncing the session FS back into the local workspace (the CI session's
+# working dir is shared and pre-populated, so we walk it deliberately rather than wholesale).
+_CI_MAX_SYNC_FILES = 500
+_CI_MAX_SYNC_DEPTH = 8
+# Interpreter-internal top-level entries to never sync back, as a safety net if the
+# per-session baseline capture fails (see ``_session_for``). The dynamic baseline is the
+# primary mechanism; this just guards the heavy/obvious ones.
+_CI_SYSTEM_NAMES = {
+    "node_modules", ".ipython", "log", "run", "package.json", "package-lock.json",
+    "nodejs-js-execution", "nodejs-ts-execution",
+}
+
+
 class AgentCoreCodeInterpreterRunner(SandboxRunner):
     """Run code/commands in an AWS Bedrock AgentCore Code Interpreter microVM.
 
@@ -303,7 +316,8 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         # FS tools + artifact detection see them). Can be disabled for execute-only use.
         self.sync_back = bool(self.cfg.get("sync_back", True))
         self._client = None
-        self._sessions: dict[str, str] = {}     # workdir.name -> sessionId
+        self._sessions: dict[str, str] = {}        # workdir.name -> sessionId
+        self._baseline: dict[str, set[str]] = {}   # workdir.name -> pre-existing top-level entries
         self._lock = threading.Lock()
         self._fallback = LocalSubprocessRunner()
 
@@ -332,6 +346,10 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             sessionTimeoutSeconds=self.session_timeout,
         )
         sid = resp["sessionId"]
+        # The CI session's working dir is shared and pre-populated (node_modules, the
+        # IPython profile, etc.). Snapshot those top-level names now, before we sync any
+        # workspace files in, so sync-out can tell *our* files from the interpreter's.
+        baseline = self._capture_baseline(sid)
         with self._lock:
             # Another thread may have created one concurrently; keep the first and
             # drop ours so we don't leak a session.
@@ -340,11 +358,20 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                 other = sid
             else:
                 self._sessions[key] = sid
+                self._baseline[key] = baseline
                 other = None
         if other:
             self._stop(other)
             return existing
         return sid
+
+    def _capture_baseline(self, sid: str) -> set[str]:
+        try:
+            listing = self._consume(self._invoke(sid, "listFiles", {"directoryPath": "."}))
+            return {b.get("name") for b in listing["content"] if b.get("name")}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("AgentCore baseline capture failed: %s", exc)
+            return set()
 
     def _stop(self, sid: str) -> None:
         try:
@@ -357,6 +384,7 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
     def close_session(self, workdir: Path) -> None:
         with self._lock:
             sid = self._sessions.pop(workdir.name, None)
+            self._baseline.pop(workdir.name, None)
         if sid:
             self._stop(sid)
 
@@ -373,10 +401,11 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         The response carries an event stream under ``stream``; each ``result`` event has
         ``result.structuredContent`` (clean ``stdout``/``stderr``/``exitCode`` for
         execute* tools) and ``result.content[]`` (MCP-style ``text``/``resource`` blocks,
-        used by the file tools). Shapes are from the ``bedrock-agentcore`` botocore model.
+        used by the file tools). Shapes verified against a live AgentCore Code Interpreter
+        and the ``bedrock-agentcore`` botocore model.
         """
         out = {"stdout": "", "stderr": "", "exit_code": 0, "is_error": False,
-               "content": [], "text": ""}
+               "has_structured": False, "content": [], "text": ""}
         text_parts: list[str] = []
         for event in resp.get("stream", []):
             result = event.get("result")
@@ -384,19 +413,25 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                 continue
             if result.get("isError"):
                 out["is_error"] = True
-            sc = result.get("structuredContent") or {}
-            out["stdout"] += sc.get("stdout") or ""
-            out["stderr"] += sc.get("stderr") or ""
-            if sc.get("exitCode") is not None:
-                try:
-                    out["exit_code"] = int(sc["exitCode"])
-                except (TypeError, ValueError):
-                    pass
+            sc = result.get("structuredContent")
+            if sc:
+                out["has_structured"] = True
+                out["stdout"] += sc.get("stdout") or ""
+                out["stderr"] += sc.get("stderr") or ""
+                if sc.get("exitCode") is not None:
+                    try:
+                        out["exit_code"] = int(sc["exitCode"])
+                    except (TypeError, ValueError):
+                        pass
             for block in result.get("content", []) or []:
                 out["content"].append(block)
                 if block.get("type") == "text" and block.get("text"):
                     text_parts.append(block["text"])
-        out["text"] = "\n".join(text_parts)
+        # executeCommand returns terminal CRLF line endings; normalize to match the
+        # local/container runners (plain \n) so output is consistent across runners.
+        out["stdout"] = out["stdout"].replace("\r\n", "\n")
+        out["stderr"] = out["stderr"].replace("\r\n", "\n")
+        out["text"] = "\n".join(text_parts).replace("\r\n", "\n")
         return out
 
     # -- local <-> session file sync ----------------------------------------
@@ -413,26 +448,41 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                     continue
             except OSError:
                 continue
-            entry: dict = {"path": str(rel)}
             try:
-                entry["text"] = p.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                try:
-                    entry["blob"] = p.read_bytes()   # binary file -> blob (model supports it)
-                except OSError:
-                    continue
+                data = p.read_bytes()
+            except OSError:
+                continue
+            entry: dict = {"path": str(rel)}
+            # Decide text vs binary from the raw bytes — and decode without newline
+            # translation, so CRLF/CR files round-trip byte-for-byte (read_text would
+            # rewrite line endings and make untouched files look changed every run).
+            try:
+                entry["text"] = data.decode("utf-8")
+            except UnicodeDecodeError:
+                entry["blob"] = data             # binary file -> blob (model supports it)
             files.append(entry)
         if files:
             self._invoke(sid, "writeFiles", {"content": files})
 
     def _sync_out(self, sid: str, workdir: Path) -> None:
+        """Pull files the run produced/changed back into the local workspace.
+
+        ``listFiles`` is one level deep and the session's working dir is shared with
+        interpreter internals, so we walk it recursively, skip the baseline (pre-existing)
+        top-level entries, then ``readFiles`` the rest and write only genuinely-changed
+        content back (so unchanged inputs don't get falsely flagged as artifacts).
+        """
         if not self.sync_back:
             return
         try:
-            listing = self._consume(self._invoke(sid, "listFiles", {"directoryPath": "."}))
-            paths = self._listing_paths(listing)
+            baseline = self._baseline.get(workdir.name, set()) | _CI_SYSTEM_NAMES
+            paths = self._walk_remote(sid, ".", baseline)
             if not paths:
                 return
+            if len(paths) > _CI_MAX_SYNC_FILES:
+                logger.warning("AgentCore sync_out: %d files exceed cap %d; syncing first %d",
+                               len(paths), _CI_MAX_SYNC_FILES, _CI_MAX_SYNC_FILES)
+                paths = paths[:_CI_MAX_SYNC_FILES]
             read = self._consume(self._invoke(sid, "readFiles", {"paths": paths}))
             self._write_back(read["content"], workdir)
         except Exception as exc:  # noqa: BLE001
@@ -440,56 +490,79 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             # breaks the run — it just means produced files may not appear locally.
             logger.warning("AgentCore sync_out failed: %s", exc)
 
-    @staticmethod
-    def _safe_rel(path: str) -> str | None:
-        """Return a workspace-relative path, or None if it escapes/looks unsafe."""
-        if not path:
-            return None
-        path = path.lstrip("./")
-        if not path or path.startswith("/") or ".." in Path(path).parts:
-            return None
-        return path
+    def _walk_remote(self, sid: str, dirpath: str, baseline: set[str], depth: int = 0) -> list[str]:
+        """Recursively list the session FS, returning relative file paths worth syncing.
 
-    def _listing_paths(self, listing: dict) -> list[str]:
-        """Best-effort parse of ``listFiles`` output into relative file paths.
-
-        listFiles surfaces entries either as ``resource`` content blocks (with a ``uri``)
-        or as a text block (newline- or JSON-listed). We accept whichever appears and skip
-        anything that doesn't look like a safe relative path.
+        ``listFiles`` returns ``resource_link`` blocks with ``name`` + ``description``
+        ("File"|"Directory"). Baseline/system names are skipped at the top level; nested
+        dirs (our own subdirs) are walked in full.
         """
-        paths: list[str] = []
-        for block in listing.get("content", []):
-            if block.get("type") in ("resource", "resource_link"):
-                uri = block.get("uri") or (block.get("resource") or {}).get("uri") or block.get("name")
-                rel = self._safe_rel(str(uri)) if uri else None
-                if rel:
-                    paths.append(rel)
-            elif block.get("type") == "text" and block.get("text"):
-                for line in block["text"].splitlines():
-                    rel = self._safe_rel(line.strip().strip('",[]'))
-                    if rel:
-                        paths.append(rel)
-        # De-dup, preserve order.
-        seen: set[str] = set()
-        return [p for p in paths if not (p in seen or seen.add(p))]
+        if depth > _CI_MAX_SYNC_DEPTH:
+            return []
+        listing = self._consume(self._invoke(sid, "listFiles", {"directoryPath": dirpath}))
+        files: list[str] = []
+        for block in listing["content"]:
+            name = block.get("name")
+            if not name or "/" in name or name in (".", ".."):
+                continue
+            if name in _IGNORE_DIRS:
+                continue
+            if depth == 0 and name in baseline:
+                continue  # interpreter-internal / pre-existing entry — not ours
+            rel = name if dirpath == "." else f"{dirpath}/{name}"
+            if block.get("description") == "Directory":
+                files.extend(self._walk_remote(sid, rel, baseline, depth + 1))
+            else:
+                files.append(rel)
+            if len(files) >= _CI_MAX_SYNC_FILES:
+                break
+        return files
+
+    @staticmethod
+    def _uri_to_rel(uri: str | None) -> str | None:
+        """Turn a CI ``file:///...`` uri into a safe workspace-relative path, or None."""
+        if not uri:
+            return None
+        s = str(uri)
+        if s.startswith("file://"):
+            s = s[len("file://"):]
+        s = s.lstrip("/")
+        if s.startswith("./"):
+            s = s[2:]
+        if not s or s.startswith("/") or ".." in Path(s).parts:
+            return None
+        return s
 
     def _write_back(self, content: list[dict], workdir: Path) -> None:
-        """Write ``readFiles`` content blocks back into the local workspace."""
+        """Write ``readFiles`` ``resource`` blocks back, skipping unchanged files.
+
+        Each block is ``{"type":"resource","resource":{"uri","text"|"blob",...}}``. We
+        only write when the content differs from what's already on disk, so re-syncing an
+        unchanged input file doesn't bump its mtime and get it mis-detected as an artifact.
+        """
         for block in content:
             res = block.get("resource") if block.get("type") == "resource" else None
-            uri = (res or {}).get("uri") or block.get("uri") or block.get("name")
-            rel = self._safe_rel(str(uri)) if uri else None
+            if res is None:
+                continue
+            rel = self._uri_to_rel(res.get("uri"))
             if not rel:
                 continue
+            text = res.get("text")
+            blob = res.get("blob")
+            if text is not None:
+                data = text.encode("utf-8")
+            elif blob is not None:
+                data = blob if isinstance(blob, (bytes, bytearray)) else bytes(blob)
+            else:
+                continue
             dest = workdir / rel
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            text = (res or {}).get("text", block.get("text"))
-            blob = (res or {}).get("blob", block.get("data"))
             try:
-                if text is not None:
-                    dest.write_text(text, encoding="utf-8")
-                elif blob is not None:
-                    dest.write_bytes(blob if isinstance(blob, (bytes, bytearray)) else bytes(blob))
+                # Skip rewriting unchanged content (comparing raw bytes, no newline
+                # translation) so untouched inputs don't get mis-flagged as artifacts.
+                if dest.exists() and dest.read_bytes() == data:
+                    continue
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(data)
             except OSError as exc:
                 logger.warning("AgentCore write_back %s failed: %s", rel, exc)
 
@@ -530,15 +603,19 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             self._sync_in(sid, workdir)
             res = self._consume(do_invoke(sid))
             self._sync_out(sid, workdir)
-            exit_code = res["exit_code"]
+            if res["has_structured"]:
+                # execute* tools: trust the clean structuredContent split.
+                stdout, stderr, exit_code = res["stdout"], res["stderr"], res["exit_code"]
+            else:
+                # No structuredContent (unexpected for execute*): fall back to text blocks.
+                stdout, stderr, exit_code = res["text"], "", 0
             # isError without a non-zero code still means failure; surface it so tools'
             # `is_error = exit_code != 0` is correct.
             if res["is_error"] and exit_code == 0:
                 exit_code = 1
-            stdout = res["stdout"] or res["text"]
             return ExecResult(
                 stdout=_truncate(stdout),
-                stderr=_truncate(res["stderr"]),
+                stderr=_truncate(stderr),
                 exit_code=exit_code,
                 duration_s=round(time.monotonic() - start, 3),
                 artifacts=collect_artifacts(workdir, before),

--- a/backend/config.yml.example
+++ b/backend/config.yml.example
@@ -157,6 +157,10 @@ web_search:
 # Code/shell execution sandbox.
 #   runner: local      -> run on the host (fast, trusts the host; fine for single-user/dev)
 #   runner: container  -> run in an ephemeral, resource-limited container per execution.
+#   runner: agentcore  -> run OFF-HOST in an AWS Bedrock AgentCore Code Interpreter microVM
+#                         (kernel-level Firecracker isolation; untrusted code never touches
+#                         the Phlox host). Needs AWS creds + the IAM actions below. Falls
+#                         back to local on any AWS error.
 # The container runner targets the Docker-compatible CLI, so it works with Podman
 # (including Podman's Docker-compat mode) and Docker, on Windows/macOS/Linux. Required for
 # untrusted / multi-user execution. Falls back to local if no engine is found.
@@ -173,6 +177,19 @@ sandbox:
     cpus: "1.0"
     pids_limit: 256
     network: none                # none (most secure) | bridge (allow network, e.g. pip)
+  # Only used when runner: agentcore. FILE-ONLY. The local workspace stays authoritative —
+  # files are synced into the session before each run and produced files synced back out, so
+  # all of Phlox's file tools + artifact detection keep working. Uses the default AWS
+  # credential chain (env / shared config / instance role), or set `profile:` for a named one.
+  # IAM: bedrock-agentcore:StartCodeInterpreterSession, :InvokeCodeInterpreter,
+  #      :StopCodeInterpreterSession.
+  agentcore:
+    identifier: aws.codeinterpreter.v1   # built-in Code Interpreter
+    region: us-west-2                    # a region where Code Interpreter is available
+    # profile:                           # optional named AWS profile; else the default chain
+    session_timeout_seconds: 900         # idle session TTL (also torn down on conversation delete)
+    # max_sync_file_bytes: 5000000       # skip syncing files larger than this (bounds per-call cost)
+    # sync_back: true                    # sync session-produced files back into the local workspace
 
 # Vector store for document/RAG search. FILE-ONLY (not in the admin UI). Default is Qdrant in
 # embedded file-based mode (no server needed; works the same on Windows/macOS/Linux). To scale

--- a/backend/tests/test_sandbox_agentcore.py
+++ b/backend/tests/test_sandbox_agentcore.py
@@ -1,0 +1,247 @@
+"""Tests for the AgentCore remote sandbox runner + the additive close_session hook.
+
+No live AWS is needed: the boto3 client is replaced with a fake whose responses mirror
+the ``bedrock-agentcore`` event-stream shapes (``result.structuredContent`` +
+``result.content[]``). These lock in the runner's behavior — dispatch, fallback, output
+parsing, file sync, and deterministic session teardown — independent of the real service.
+"""
+import pytest
+
+from app.sandbox import runner as runner_mod
+from app.sandbox.runner import (
+    AgentCoreCodeInterpreterRunner,
+    LocalSubprocessRunner,
+)
+
+
+# --------------------------------------------------------------------------- #
+# A fake bedrock-agentcore client recording calls and returning modeled shapes
+# --------------------------------------------------------------------------- #
+def _event(content=None, structured=None, is_error=False):
+    result = {"content": content or [], "isError": is_error}
+    if structured is not None:
+        result["structuredContent"] = structured
+    return {"result": result}
+
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+        self.session_counter = 0
+        self.stopped = []
+        self.written = []          # captured writeFiles content
+        self.files = {}            # path -> text, returned by listFiles/readFiles
+
+    def start_code_interpreter_session(self, **kw):
+        self.calls.append(("start", kw))
+        self.session_counter += 1
+        return {"sessionId": f"sess-{self.session_counter}"}
+
+    def stop_code_interpreter_session(self, **kw):
+        self.calls.append(("stop", kw))
+        self.stopped.append(kw["sessionId"])
+        return {}
+
+    def invoke_code_interpreter(self, **kw):
+        self.calls.append((kw["name"], kw))
+        name, args = kw["name"], kw.get("arguments", {})
+        if name == "executeCode":
+            return {"stream": [_event(
+                content=[{"type": "text", "text": "hello from code"}],
+                structured={"stdout": "hello from code\n", "stderr": "", "exitCode": 0},
+            )]}
+        if name == "executeCommand":
+            return {"stream": [_event(
+                structured={"stdout": "cmd-out\n", "stderr": "warn\n", "exitCode": 3},
+            )]}
+        if name == "writeFiles":
+            self.written = args.get("content", [])
+            return {"stream": [_event(content=[{"type": "text", "text": "ok"}])]}
+        if name == "listFiles":
+            blocks = [{"type": "resource", "uri": p} for p in self.files]
+            return {"stream": [_event(content=blocks)]}
+        if name == "readFiles":
+            blocks = [
+                {"type": "resource", "resource": {"type": "text", "uri": p, "text": t}}
+                for p, t in self.files.items()
+                if p in args.get("paths", [])
+            ]
+            return {"stream": [_event(content=blocks)]}
+        return {"stream": [_event()]}
+
+
+@pytest.fixture
+def fake_runner():
+    r = AgentCoreCodeInterpreterRunner({"region": "us-west-2"})
+    fake = FakeClient()
+    r._client = fake          # bypass boto3 entirely
+    return r, fake
+
+
+# --------------------------------------------------------------------------- #
+# get_runner() dispatch + fallback
+# --------------------------------------------------------------------------- #
+def test_get_runner_returns_agentcore_when_configured(monkeypatch):
+    monkeypatch.setattr(
+        runner_mod, "get_runner", runner_mod.get_runner
+    )  # keep ref; we patch config below
+    from app import config
+
+    monkeypatch.setattr(
+        config, "get_sandbox_config",
+        lambda: {"runner": "agentcore", "agentcore": {"region": "us-west-2"}},
+    )
+    runner_mod.reset_runner()
+    try:
+        r = runner_mod.get_runner()
+        assert isinstance(r, AgentCoreCodeInterpreterRunner)
+    finally:
+        runner_mod.reset_runner()
+
+
+def test_get_runner_falls_back_to_local_on_construction_error(monkeypatch):
+    from app import config
+
+    monkeypatch.setattr(
+        config, "get_sandbox_config",
+        lambda: {"runner": "agentcore", "agentcore": {"region": "us-west-2"}},
+    )
+
+    def boom(_cfg):
+        raise RuntimeError("no creds")
+
+    monkeypatch.setattr(runner_mod, "AgentCoreCodeInterpreterRunner", boom)
+    runner_mod.reset_runner()
+    try:
+        assert isinstance(runner_mod.get_runner(), LocalSubprocessRunner)
+    finally:
+        runner_mod.reset_runner()
+
+
+# --------------------------------------------------------------------------- #
+# run_code / run_command parse structuredContent (the resolved INFERRED bit)
+# --------------------------------------------------------------------------- #
+def test_run_code_parses_structured_stdout(fake_runner, tmp_path):
+    r, fake = fake_runner
+    res = r.run_code("print('hi')", "python", tmp_path)
+    assert res.stdout.strip() == "hello from code"
+    assert res.exit_code == 0
+    # a session was opened and reused
+    assert any(c[0] == "start" for c in fake.calls)
+
+
+def test_run_code_node_maps_to_javascript(fake_runner, tmp_path):
+    r, fake = fake_runner
+    r.run_code("console.log(1)", "node", tmp_path)
+    code_call = next(c for c in fake.calls if c[0] == "executeCode")
+    assert code_call[1]["arguments"]["language"] == "javascript"
+
+
+def test_run_command_surfaces_stderr_and_exit_code(fake_runner, tmp_path):
+    r, _ = fake_runner
+    res = r.run_command(["/bin/sh", "-c", "do-thing"], tmp_path)
+    assert res.stdout.strip() == "cmd-out"
+    assert res.stderr.strip() == "warn"
+    assert res.exit_code == 3
+
+
+def test_is_error_without_exit_code_becomes_nonzero(fake_runner, tmp_path, monkeypatch):
+    r, fake = fake_runner
+
+    def err_invoke(**kw):
+        fake.calls.append((kw["name"], kw))
+        if kw["name"] == "executeCode":
+            return {"stream": [{"result": {"content": [], "isError": True}}]}
+        return {"stream": [{"result": {"content": []}}]}
+
+    fake.invoke_code_interpreter = err_invoke
+    res = r.run_code("boom", "python", tmp_path)
+    assert res.exit_code != 0
+
+
+# --------------------------------------------------------------------------- #
+# file sync (in + out) keeps the local workspace authoritative
+# --------------------------------------------------------------------------- #
+def test_sync_in_uploads_local_files(fake_runner, tmp_path):
+    r, fake = fake_runner
+    (tmp_path / "a.txt").write_text("local-content", encoding="utf-8")
+    r.run_code("print(1)", "python", tmp_path)
+    paths = {f["path"] for f in fake.written}
+    assert "a.txt" in paths
+    assert any(f.get("text") == "local-content" for f in fake.written)
+
+
+def test_sync_out_writes_produced_files_back_locally(fake_runner, tmp_path):
+    r, fake = fake_runner
+    # The session "produces" a new file that isn't on local disk yet.
+    fake.files = {"out.csv": "x,y\n1,2\n"}
+    res = r.run_code("write csv", "python", tmp_path)
+    written_back = tmp_path / "out.csv"
+    assert written_back.exists()
+    assert written_back.read_text(encoding="utf-8") == "x,y\n1,2\n"
+    # ...and it is detected as an artifact by the normal mtime diff.
+    assert any(a["path"] == "out.csv" for a in res.artifacts)
+
+
+def test_sync_out_ignores_unsafe_paths(fake_runner, tmp_path):
+    r, fake = fake_runner
+    fake.files = {"/etc/passwd": "root:x:0:0", "../escape": "no", "ok.txt": "fine"}
+    r.run_code("x", "python", tmp_path)
+    assert (tmp_path / "ok.txt").exists()
+    assert not (tmp_path / "etc" / "passwd").exists()
+    assert not (tmp_path.parent / "escape").exists()
+
+
+# --------------------------------------------------------------------------- #
+# AWS failure -> graceful local fallback
+# --------------------------------------------------------------------------- #
+def test_run_falls_back_to_local_on_aws_error(tmp_path):
+    r = AgentCoreCodeInterpreterRunner({"region": "us-west-2"})
+
+    class Boom:
+        def start_code_interpreter_session(self, **kw):
+            raise RuntimeError("network down")
+
+    r._client = Boom()
+    res = r.run_code("print('local fallback works')", "python", tmp_path)
+    # The local runner actually executed the code.
+    assert res.exit_code == 0
+    assert "local fallback works" in res.stdout
+
+
+# --------------------------------------------------------------------------- #
+# close_session: deterministic teardown on the remote runner; no-op elsewhere
+# --------------------------------------------------------------------------- #
+def test_close_session_stops_remote_session(fake_runner, tmp_path):
+    r, fake = fake_runner
+    r.run_code("print(1)", "python", tmp_path)        # opens a session
+    sid = r._sessions[tmp_path.name]
+    r.close_session(tmp_path)
+    assert sid in fake.stopped
+    assert tmp_path.name not in r._sessions
+    # Idempotent: closing again does nothing.
+    r.close_session(tmp_path)
+
+
+def test_close_session_is_noop_for_local_runner(tmp_path):
+    # The base no-op must not raise — existing runners inherit it unchanged.
+    LocalSubprocessRunner().close_session(tmp_path)
+
+
+def test_close_session_session_reused_across_runs(fake_runner, tmp_path):
+    r, fake = fake_runner
+    r.run_code("print(1)", "python", tmp_path)
+    r.run_code("print(2)", "python", tmp_path)
+    starts = [c for c in fake.calls if c[0] == "start"]
+    assert len(starts) == 1     # one session reused, not re-created per call
+
+
+# --------------------------------------------------------------------------- #
+# config defaults
+# --------------------------------------------------------------------------- #
+def test_sandbox_config_has_agentcore_defaults():
+    from app.config import get_sandbox_config
+
+    cfg = get_sandbox_config()
+    assert cfg["agentcore"]["identifier"] == "aws.codeinterpreter.v1"
+    assert cfg["agentcore"]["session_timeout_seconds"] == 900

--- a/backend/tests/test_sandbox_agentcore.py
+++ b/backend/tests/test_sandbox_agentcore.py
@@ -1,9 +1,12 @@
 """Tests for the AgentCore remote sandbox runner + the additive close_session hook.
 
-No live AWS is needed: the boto3 client is replaced with a fake whose responses mirror
-the ``bedrock-agentcore`` event-stream shapes (``result.structuredContent`` +
-``result.content[]``). These lock in the runner's behavior — dispatch, fallback, output
-parsing, file sync, and deterministic session teardown — independent of the real service.
+No live AWS is needed: the boto3 client is replaced with a ``FakeClient`` whose responses
+mirror the **real** ``bedrock-agentcore`` Code Interpreter shapes captured from a live
+session — ``result.structuredContent`` (stdout/stderr/exitCode) for execute*, and a small
+virtual filesystem behind ``writeFiles``/``listFiles``/``readFiles`` (one-level
+``resource_link`` listings with name+description; ``resource`` blocks with ``file:///``
+uris on read). These lock in dispatch, fallback, output parsing, the baseline-aware file
+sync, and deterministic session teardown — independent of the real service.
 """
 import pytest
 
@@ -15,7 +18,7 @@ from app.sandbox.runner import (
 
 
 # --------------------------------------------------------------------------- #
-# A fake bedrock-agentcore client recording calls and returning modeled shapes
+# A fake bedrock-agentcore client backed by a virtual session filesystem
 # --------------------------------------------------------------------------- #
 def _event(content=None, structured=None, is_error=False):
     result = {"content": content or [], "isError": is_error}
@@ -24,13 +27,20 @@ def _event(content=None, structured=None, is_error=False):
     return {"result": result}
 
 
+# Mirrors the live session's pre-populated working dir (interpreter internals).
+_SYSTEM_FILES = {"node_modules/x.js": "//", "package.json": "{}", "log/app.log": ""}
+
+
 class FakeClient:
     def __init__(self):
         self.calls = []
         self.session_counter = 0
         self.stopped = []
-        self.written = []          # captured writeFiles content
-        self.files = {}            # path -> text, returned by listFiles/readFiles
+        # path -> str|bytes. Starts with system files; writeFiles/run add ours.
+        self.fs: dict[str, object] = dict(_SYSTEM_FILES)
+        # Files an executeCode call "produces" — merged into fs *after* session start, so
+        # they're not part of the baseline (i.e. they look like genuine run output).
+        self.produce: dict[str, object] = {}
 
     def start_code_interpreter_session(self, **kw):
         self.calls.append(("start", kw))
@@ -42,30 +52,60 @@ class FakeClient:
         self.stopped.append(kw["sessionId"])
         return {}
 
+    def _children(self, dirpath):
+        prefix = "" if dirpath in (".", "") else dirpath.rstrip("/") + "/"
+        dirs, files = set(), set()
+        for path in self.fs:
+            if prefix and not path.startswith(prefix):
+                continue
+            rest = path[len(prefix):]
+            if "/" in rest:
+                dirs.add(rest.split("/", 1)[0])
+            elif rest:
+                files.add(rest)
+        blocks = []
+        for d in sorted(dirs):
+            blocks.append({"type": "resource_link", "uri": f"file:///{prefix}{d}",
+                           "name": d, "description": "Directory"})
+        for f in sorted(files):
+            blocks.append({"type": "resource_link", "uri": f"file:///{prefix}{f}",
+                           "name": f, "description": "File"})
+        return blocks
+
     def invoke_code_interpreter(self, **kw):
         self.calls.append((kw["name"], kw))
         name, args = kw["name"], kw.get("arguments", {})
         if name == "executeCode":
+            self.fs.update(self.produce)
             return {"stream": [_event(
                 content=[{"type": "text", "text": "hello from code"}],
-                structured={"stdout": "hello from code\n", "stderr": "", "exitCode": 0},
+                structured={"stdout": "hello from code", "stderr": "", "exitCode": 0},
             )]}
         if name == "executeCommand":
             return {"stream": [_event(
-                structured={"stdout": "cmd-out\n", "stderr": "warn\n", "exitCode": 3},
+                structured={"stdout": "cmd-out\r\n", "stderr": "warn\r\n", "exitCode": 3},
             )]}
         if name == "writeFiles":
-            self.written = args.get("content", [])
-            return {"stream": [_event(content=[{"type": "text", "text": "ok"}])]}
+            for f in args.get("content", []):
+                self.fs[f["path"]] = f["text"] if "text" in f else f.get("blob")
+            n = len(args.get("content", []))
+            return {"stream": [_event(content=[{"type": "text", "text": f"Successfully wrote all {n} files"}])]}
         if name == "listFiles":
-            blocks = [{"type": "resource", "uri": p} for p in self.files]
-            return {"stream": [_event(content=blocks)]}
+            return {"stream": [_event(content=self._children(args.get("directoryPath", ".")))]}
         if name == "readFiles":
-            blocks = [
-                {"type": "resource", "resource": {"type": "text", "uri": p, "text": t}}
-                for p, t in self.files.items()
-                if p in args.get("paths", [])
-            ]
+            blocks = []
+            for p in args.get("paths", []):
+                if p not in self.fs:
+                    return {"stream": [_event(
+                        content=[{"type": "text", "text": f"Error executing tool read_files: File {p} not found"}],
+                        is_error=True)]}
+                v = self.fs[p]
+                res = {"uri": f"file:///{p}"}
+                if isinstance(v, (bytes, bytearray)):
+                    res["blob"] = bytes(v)
+                else:
+                    res["text"] = v
+                blocks.append({"type": "resource", "resource": res})
             return {"stream": [_event(content=blocks)]}
         return {"stream": [_event()]}
 
@@ -166,29 +206,78 @@ def test_sync_in_uploads_local_files(fake_runner, tmp_path):
     r, fake = fake_runner
     (tmp_path / "a.txt").write_text("local-content", encoding="utf-8")
     r.run_code("print(1)", "python", tmp_path)
-    paths = {f["path"] for f in fake.written}
-    assert "a.txt" in paths
-    assert any(f.get("text") == "local-content" for f in fake.written)
+    # writeFiles landed the local file into the session FS.
+    assert fake.fs.get("a.txt") == "local-content"
+
+
+def test_sync_in_uploads_binary_as_blob(fake_runner, tmp_path):
+    r, fake = fake_runner
+    payload = b"\x89PNG\r\n\x1a\n\xff\xfe\x00\x01"   # non-UTF-8 bytes -> blob path
+    (tmp_path / "pic.bin").write_bytes(payload)
+    r.run_code("print(1)", "python", tmp_path)
+    assert fake.fs.get("pic.bin") == payload
+
+
+def test_sync_in_preserves_crlf_text_byte_for_byte(fake_runner, tmp_path):
+    r, fake = fake_runner
+    # A valid-UTF-8 file with CRLF must round-trip unchanged (no newline translation).
+    (tmp_path / "crlf.txt").write_bytes(b"line1\r\nline2\r\n")
+    r.run_code("print(1)", "python", tmp_path)
+    assert fake.fs.get("crlf.txt") == "line1\r\nline2\r\n"
 
 
 def test_sync_out_writes_produced_files_back_locally(fake_runner, tmp_path):
     r, fake = fake_runner
-    # The session "produces" a new file that isn't on local disk yet.
-    fake.files = {"out.csv": "x,y\n1,2\n"}
-    res = r.run_code("write csv", "python", tmp_path)
-    written_back = tmp_path / "out.csv"
-    assert written_back.exists()
-    assert written_back.read_text(encoding="utf-8") == "x,y\n1,2\n"
-    # ...and it is detected as an artifact by the normal mtime diff.
-    assert any(a["path"] == "out.csv" for a in res.artifacts)
+    # The session produces new files (text + nested + binary) after it starts — these are
+    # not in the baseline, so they should sync back into the local workspace.
+    fake.produce = {
+        "out.csv": "x,y\n1,2\n",
+        "produced/nested.txt": "deep",
+        "bin.dat": bytes(range(16)),
+    }
+    res = r.run_code("write files", "python", tmp_path)
+    assert (tmp_path / "out.csv").read_text(encoding="utf-8") == "x,y\n1,2\n"
+    assert (tmp_path / "produced" / "nested.txt").read_text(encoding="utf-8") == "deep"
+    assert (tmp_path / "bin.dat").read_bytes() == bytes(range(16))
+    # ...and they're detected as artifacts by the normal mtime diff.
+    art_paths = {a["path"] for a in res.artifacts}
+    assert {"out.csv", "produced/nested.txt", "bin.dat"} <= art_paths
 
 
-def test_sync_out_ignores_unsafe_paths(fake_runner, tmp_path):
+def test_sync_out_skips_interpreter_system_files(fake_runner, tmp_path):
     r, fake = fake_runner
-    fake.files = {"/etc/passwd": "root:x:0:0", "../escape": "no", "ok.txt": "fine"}
-    r.run_code("x", "python", tmp_path)
-    assert (tmp_path / "ok.txt").exists()
-    assert not (tmp_path / "etc" / "passwd").exists()
+    r.run_code("noop", "python", tmp_path)
+    # The pre-existing interpreter files must NOT be dragged into the local workspace.
+    assert not (tmp_path / "node_modules").exists()
+    assert not (tmp_path / "package.json").exists()
+    assert not (tmp_path / "log").exists()
+
+
+def test_sync_out_unchanged_input_not_reflagged_as_artifact(fake_runner, tmp_path):
+    r, _ = fake_runner
+    (tmp_path / "input.txt").write_text("unchanged", encoding="utf-8")
+    res = r.run_code("noop", "python", tmp_path)
+    # The input round-trips out unchanged; write_back must skip it so it isn't a false artifact.
+    assert all(a["path"] != "input.txt" for a in res.artifacts)
+
+
+def test_uri_to_rel_rejects_escapes(fake_runner):
+    r, _ = fake_runner
+    assert r._uri_to_rel("file:///hello.txt") == "hello.txt"
+    assert r._uri_to_rel("file:///sub/dir/nested.txt") == "sub/dir/nested.txt"
+    assert r._uri_to_rel("file:///./produced/out.csv") == "produced/out.csv"
+    assert r._uri_to_rel("file:///../escape") is None
+    assert r._uri_to_rel("") is None
+
+
+def test_write_back_ignores_unsafe_uris(fake_runner, tmp_path):
+    r, _ = fake_runner
+    content = [
+        {"type": "resource", "resource": {"uri": "file:///../escape", "text": "no"}},
+        {"type": "resource", "resource": {"uri": "file:///ok.txt", "text": "fine"}},
+    ]
+    r._write_back(content, tmp_path)
+    assert (tmp_path / "ok.txt").read_text(encoding="utf-8") == "fine"
     assert not (tmp_path.parent / "escape").exists()
 
 

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -155,6 +155,19 @@ instead of breaking the turn.
 4. Set `sandbox.runner: agentcore` and restart the backend. (`boto3` is already a Phlox
    dependency — it's also used by the Bedrock model provider.)
 
+**Verify it end-to-end.** With AWS creds in your environment, run the live check (it uses a
+throwaway temp data dir and tears its session down afterwards):
+
+```bash
+python scripts/e2e_agentcore.py --region us-west-2        # add --profile NAME if needed
+```
+
+It drives the real tools (`execute_python`/`run_shell`/`write_file`/…) through the runner,
+asserting execution output, file sync in/out, binary round-trip, artifact detection, that
+interpreter system files stay out of the workspace, session reuse, and `close_session`
+teardown — and it fails loudly (rather than silently falling back to local) if AWS is
+misconfigured. Exit code 0 means the feature works against your account.
+
 ### Tuning
 
 | Key | Default | Meaning |

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -1,23 +1,26 @@
 # Code-Execution Sandbox
 
 Phlox runs agent code/shell tools (`execute_python`, `execute_node`, `run_shell`)
-through a swappable **`SandboxRunner`** (`backend/app/sandbox/runner.py`). Two
+through a swappable **`SandboxRunner`** (`backend/app/sandbox/runner.py`). Three
 implementations ship; pick one in `config.yml`.
 
 | Runner | Isolation | When to use |
 |---|---|---|
 | `local` (default) | Subprocess on the host, rooted at the conversation workspace, with timeouts + output caps | Single-user / local / trusted dev |
-| `container` | Ephemeral **Podman/Docker** container, resource-limited, network-isolated, workspace bind-mounted | Untrusted input, multi-user, anything shared |
+| `container` | Ephemeral **Podman/Docker** container, resource-limited, network-isolated, workspace bind-mounted | Untrusted input, multi-user, anything shared, on your own host |
+| `agentcore` | **Off-host** AWS Bedrock AgentCore Code Interpreter microVM (Firecracker, kernel-level isolation) | Untrusted/multi-user when you'd rather run code off the Phlox host entirely (no local Docker needed) |
 
-Both capture **artifacts**: any file the run creates in the workspace is returned (shown
-inline / in the **Workspace Files** panel). The container runner bind-mounts the
-conversation workspace at `/work`, so files land back on the host identically.
+All three capture **artifacts**: any file the run creates in the workspace is returned (shown
+inline / in the **Workspace Files** panel). The container runner bind-mounts the conversation
+workspace at `/work`; the AgentCore runner syncs the local workspace into the remote session
+before each run and syncs produced files back out after — so in every case files land back in
+the local workspace and Phlox's file tools + artifact detection work identically.
 
 ## Configure (config.yml)
 
 ```yaml
 sandbox:
-  runner: local            # local | container
+  runner: local            # local | container | agentcore
   container:
     engine: auto           # auto | podman | docker | <full path to the binary>
     python_image: python:3.12-slim
@@ -26,6 +29,10 @@ sandbox:
     cpus: "1.0"
     pids_limit: 256
     network: none          # none (most secure) | bridge (allow network, e.g. pip install)
+  agentcore:               # only used when runner: agentcore (see below)
+    identifier: aws.codeinterpreter.v1
+    region: us-west-2
+    session_timeout_seconds: 900
 ```
 
 The `runner` type and engine come from this file. The **container resource limits**
@@ -98,6 +105,69 @@ run time). Add packages your workflows need rather than leaving the agent to ins
 > agent no longer needs egress to fetch them. Keep `bridge` only if you still want the
 > agent to install ad-hoc packages at runtime.
 
+## Remote runner: AWS Bedrock AgentCore Code Interpreter (`agentcore`)
+
+The `local` and `container` runners both execute agent-generated code **on the Phlox host**
+(`container` adds a shared-kernel namespace; `local` runs as the Phlox process). The
+`agentcore` runner instead executes it **off-host** in a managed AWS Bedrock AgentCore Code
+Interpreter — a Firecracker microVM with **kernel-level isolation** — so untrusted code never
+touches the Phlox host at all. Useful for hosted/multi-user Phlox where you'd rather not run
+arbitrary code locally and don't want to operate Docker yourself.
+
+**The local workspace stays authoritative.** Phlox's file tools (`read_file`/`write_file`/
+`edit_file`/glob/grep) and artifact detection operate on the local `data/workspaces/<id>/`
+dir. The runner therefore:
+
+1. opens **one Code Interpreter session per conversation** (lazily, on first run),
+2. **syncs the local workspace in** (`writeFiles`) before each run,
+3. invokes `executeCode` / `executeCommand`, reading the clean `stdout`/`stderr`/`exitCode`
+   from the response's `structuredContent`,
+4. **syncs produced files back out** (`listFiles` + `readFiles`) into the local dir, where
+   the normal mtime diff picks them up as artifacts,
+5. tears the session down deterministically when the **conversation is deleted** (via the
+   additive `SandboxRunner.close_session(workdir)` hook) — no leaked sessions, no TTL reaper.
+
+On **any AWS error** (missing creds, region without Code Interpreter, throttling) the runner
+**falls back to the local runner** for that call, so a misconfiguration degrades gracefully
+instead of breaking the turn.
+
+### Setup
+
+1. **Credentials.** Uses the standard AWS credential chain (env vars, shared config,
+   instance/role). Set `agentcore.profile` to use a named profile instead.
+2. **Region.** Set `agentcore.region` to a region where AgentCore Code Interpreter is
+   available (e.g. `us-west-2`).
+3. **IAM.** The principal needs:
+   ```json
+   {
+     "Effect": "Allow",
+     "Action": [
+       "bedrock-agentcore:StartCodeInterpreterSession",
+       "bedrock-agentcore:InvokeCodeInterpreter",
+       "bedrock-agentcore:StopCodeInterpreterSession"
+     ],
+     "Resource": "*"
+   }
+   ```
+4. Set `sandbox.runner: agentcore` and restart the backend. (`boto3` is already a Phlox
+   dependency — it's also used by the Bedrock model provider.)
+
+### Tuning
+
+| Key | Default | Meaning |
+|---|---|---|
+| `identifier` | `aws.codeinterpreter.v1` | The built-in Code Interpreter to use |
+| `region` | _(none)_ | AWS region (else boto3's resolved default) |
+| `profile` | _(none)_ | Named AWS profile; else the default credential chain |
+| `session_timeout_seconds` | `900` | Idle session TTL (sessions are also closed on conversation delete) |
+| `max_sync_file_bytes` | `5000000` | Skip syncing files larger than this in/out (bounds per-call cost) |
+| `sync_back` | `true` | Sync session-produced files back into the local workspace |
+
+> **Cost/latency note:** each run does a full workspace sync in (and, by default, out). That's
+> cheap for typical scratch workspaces but scales with workspace size; raise/lower
+> `max_sync_file_bytes` or set `sync_back: false` for execute-only workloads. Binary files are
+> synced as blobs; very large or numerous files are best kept out of the workspace.
+
 ## Security properties
 
 - **Filesystem:** only the conversation workspace is mounted (`/work`); the rest of the
@@ -110,11 +180,18 @@ run time). Add packages your workflows need rather than leaving the agent to ins
 - **Timeouts:** every execution has a wall-clock timeout (per tool, default 60s).
 
 > Note: the **local** runner trusts the host and is appropriate only for single-user/local
-> or otherwise trusted use. Use the **container** runner for any untrusted or multi-user
-> deployment.
+> or otherwise trusted use. Use the **container** runner (on-host, shared kernel) or the
+> **agentcore** runner (off-host, kernel-level microVM isolation) for any untrusted or
+> multi-user deployment.
 
 ## Extending
 
-Add a new isolation strategy (e.g. a remote executor, Firecracker, gVisor) by implementing
-`SandboxRunner` and returning it from `get_runner()` in `sandbox/runner.py`. The shared
-helpers `snapshot_dir` / `collect_artifacts` handle artifact capture for any runner.
+Add a new isolation strategy (e.g. another remote executor — E2B, Modal, Daytona, remote
+Docker — or Firecracker/gVisor) by implementing `SandboxRunner` and returning it from
+`get_runner()` in `sandbox/runner.py`. The shared helpers `snapshot_dir` /
+`collect_artifacts` handle artifact capture for any runner. A runner that holds
+per-conversation remote state should override the no-op `close_session(workdir)` hook to
+release it when the conversation is deleted (as the `agentcore` runner does); `local` and
+`container` hold no session and inherit the no-op unchanged. The `agentcore` runner is the
+reference implementation for a **remote** backend: local workspace authoritative, sync
+in/out around each run, graceful fallback to local on error.

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -122,8 +122,11 @@ dir. The runner therefore:
 2. **syncs the local workspace in** (`writeFiles`) before each run,
 3. invokes `executeCode` / `executeCommand`, reading the clean `stdout`/`stderr`/`exitCode`
    from the response's `structuredContent`,
-4. **syncs produced files back out** (`listFiles` + `readFiles`) into the local dir, where
-   the normal mtime diff picks them up as artifacts,
+4. **syncs produced/changed files back out** (`listFiles` + `readFiles`) into the local dir,
+   where the normal mtime diff picks them up as artifacts. The session's working dir is
+   shared and pre-populated (interpreter internals like `node_modules`), so the runner
+   snapshots a baseline at session start and only pulls back files that aren't part of it;
+   unchanged inputs are not rewritten, so they aren't mis-flagged as artifacts,
 5. tears the session down deterministically when the **conversation is deleted** (via the
    additive `SandboxRunner.close_session(workdir)` hook) — no leaked sessions, no TTL reaper.
 

--- a/scripts/e2e_agentcore.py
+++ b/scripts/e2e_agentcore.py
@@ -1,33 +1,34 @@
 #!/usr/bin/env python3
 """End-to-end test for the AgentCore Code Interpreter sandbox runner (live AWS).
 
-Drives the feature through Phlox's **own** code paths — config selection, ``get_runner()``,
-the real ``execute_python`` / ``execute_node`` / ``run_shell`` / ``write_file`` /
-``read_file`` tools via a ``ToolContext``, and ``close_session`` — against a real AWS
-Bedrock AgentCore Code Interpreter. It proves the whole integration the agent relies on,
-without needing an LLM provider or the HTTP server.
+Exercises the exact runner contract the Phlox agent harness depends on
+(``runner.run_code`` / ``run_command`` / ``close_session``, plus the local-workspace
+file sync) against a real AWS Bedrock AgentCore Code Interpreter — proving the feature
+works end-to-end without needing an LLM provider or the HTTP server.
 
 It deliberately defeats the runner's silent local fallback: it preflights a real session
 (failing loudly if AWS is misconfigured) and asserts after every run that the remote
 session map is populated — so a green result genuinely means AWS executed the code, not
 that we quietly ran locally.
 
+Dependency-light: the core checks need only ``boto3`` (so it runs in the same venv you used
+for the API probe). Two **optional** sections — config/``get_runner()`` dispatch and the
+real tool layer — run automatically *if* the full Phlox backend deps are importable, and
+are skipped with a note otherwise.
+
 Prereqs:
-  - Run with the backend venv active (needs Phlox deps: boto3, sqlalchemy, pyyaml, ...).
-  - AWS credentials in the environment (env / shared config / SSO / role), and a region
-    where Code Interpreter is enabled.
+  - ``boto3`` installed; AWS credentials in the environment (env / shared config / SSO /
+    role); a region where Code Interpreter is enabled.
   - IAM: bedrock-agentcore:StartCodeInterpreterSession, :InvokeCodeInterpreter,
          :StopCodeInterpreterSession.
 
-Usage:
+Usage (run from the repo root):
   python scripts/e2e_agentcore.py --region us-west-2
   python scripts/e2e_agentcore.py --region us-west-2 --profile my-profile
-  python scripts/e2e_agentcore.py --region us-west-2 --keep      # don't delete workspace
-  python scripts/e2e_agentcore.py --region us-west-2 --skip-node # skip the Node check
+  python scripts/e2e_agentcore.py --region us-west-2 --keep        # keep the temp workspace
+  python scripts/e2e_agentcore.py --region us-west-2 --skip-node   # skip the Node check
 
 Exit code 0 = every check passed; 1 = a check failed (or AWS was unreachable).
-It writes only to a throwaway temp PHLOX_DATA dir and tears the session down at the end,
-so it does not touch your real Phlox data or leak AWS sessions.
 """
 from __future__ import annotations
 
@@ -48,8 +49,7 @@ _RESULTS: list[tuple[bool, str, str]] = []
 
 def check(name: str, ok: bool, detail: str = "") -> bool:
     _RESULTS.append((bool(ok), name, detail))
-    mark = "PASS" if ok else "FAIL"
-    line = f"[{mark}] {name}"
+    line = f"[{'PASS' if ok else 'FAIL'}] {name}"
     if detail:
         line += f"  — {detail}"
     print(line, flush=True)
@@ -58,6 +58,11 @@ def check(name: str, ok: bool, detail: str = "") -> bool:
 
 def section(title: str) -> None:
     print("\n" + "=" * 72 + f"\n## {title}\n" + "=" * 72, flush=True)
+
+
+def is_error(res) -> bool:
+    """Mirror how Phlox's tools derive error state from an ExecResult."""
+    return res.exit_code != 0
 
 
 # --------------------------------------------------------------------------- #
@@ -77,9 +82,157 @@ def main() -> int:
         print("ERROR: no region. Pass --region or set AWS_REGION.", file=sys.stderr)
         return 2
 
-    # ---- Isolate Phlox config + data to a throwaway dir, selecting the agentcore
-    #      runner, BEFORE importing any app module (app.config reads env at import). ----
+    # Make `app` importable when run from the repo root (only app.sandbox.runner is
+    # required for the core checks; it imports only stdlib + boto3 lazily).
+    backend = Path(__file__).resolve().parent.parent / "backend"
+    sys.path.insert(0, str(backend))
+
+    try:
+        from app.sandbox.runner import AgentCoreCodeInterpreterRunner
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: cannot import the runner ({exc}). Run from the repo root with boto3 installed.",
+              file=sys.stderr)
+        return 2
+
+    print(f"region={args.region!r} profile={args.profile!r} identifier={args.identifier!r}")
+
+    ac_cfg = {"identifier": args.identifier, "region": args.region}
+    if args.profile:
+        ac_cfg["profile"] = args.profile
+    runner = AgentCoreCodeInterpreterRunner(ac_cfg)
+
+    # A throwaway local workspace (stands in for data/workspaces/<conversation_id>/).
     tmp = Path(tempfile.mkdtemp(prefix="phlox-e2e-agentcore-"))
+    ws = tmp / "workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    print(f"workspace: {ws}")
+
+    # ---------------------------------------------------------------- #
+    section("0. (optional) config + get_runner() dispatch")
+    # ---------------------------------------------------------------- #
+    _optional_config_dispatch(tmp, args)
+
+    # ---------------------------------------------------------------- #
+    section("1. Preflight: real AWS session (defeats silent local fallback)")
+    # ---------------------------------------------------------------- #
+    # _session_for is OUTSIDE _run's try/except, so an AWS error raises here loudly
+    # instead of being swallowed by the fallback-to-local path.
+    try:
+        sid0 = runner._session_for(ws)
+        check("opened a live Code Interpreter session", bool(sid0), f"sessionId={sid0}")
+    except Exception as exc:  # noqa: BLE001
+        check("opened a live Code Interpreter session", False, f"{type(exc).__name__}: {exc}")
+        print("\nABORT: could not reach AgentCore. Check credentials, region, and IAM:")
+        print("  bedrock-agentcore:StartCodeInterpreterSession / InvokeCodeInterpreter / StopCodeInterpreterSession")
+        traceback.print_exc()
+        return _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
+
+    def assert_remote_path(label: str) -> None:
+        """After any run, the session map must be populated — else we fell back to local."""
+        check(f"{label}: ran on AWS (not local fallback)", ws.name in runner._sessions,
+              f"sessions={list(runner._sessions)}")
+
+    # ---------------------------------------------------------------- #
+    section("2. run_code(python) — stdout / exit / structuredContent")
+    # ---------------------------------------------------------------- #
+    res = runner.run_code("print('hello from agentcore')", "python", ws)
+    check("stdout captured", "hello from agentcore" in res.stdout, repr(res.stdout[:120]))
+    check("exit 0 -> not error", is_error(res) is False, f"exit={res.exit_code}")
+    check("duration recorded", res.duration_s >= 0.0, f"{res.duration_s}s")
+    assert_remote_path("run_code")
+
+    res = runner.run_code("raise SystemExit(5)", "python", ws)
+    check("nonzero exit -> error", is_error(res) is True, f"exit={res.exit_code} stderr={res.stderr[:80]!r}")
+
+    # ---------------------------------------------------------------- #
+    section("3. run_command — shell + CRLF normalization")
+    # ---------------------------------------------------------------- #
+    res = runner.run_command(["/bin/sh", "-c", "echo shell-works && pwd"], ws)
+    check("run_command stdout captured", "shell-works" in res.stdout, repr(res.stdout[:160]))
+    check("CRLF normalized to \\n (no stray \\r)", "\r" not in res.stdout)
+
+    # ---------------------------------------------------------------- #
+    section("4. sync IN — a local file is visible to the session")
+    # ---------------------------------------------------------------- #
+    (ws / "input.txt").write_text("payload-12345", encoding="utf-8")
+    res = runner.run_code("print(open('input.txt').read())", "python", ws)
+    check("local file synced into session", "payload-12345" in res.stdout, repr(res.stdout[:160]))
+
+    # ---------------------------------------------------------------- #
+    section("5. sync OUT — produced files (text + binary) come back as artifacts")
+    # ---------------------------------------------------------------- #
+    payload_hex = "89504e470d0a1a0aff00fe01"   # non-UTF-8 bytes -> exercises the blob path
+    code = textwrap.dedent(
+        f"""
+        import os
+        os.makedirs('produced', exist_ok=True)
+        open('produced/out.csv', 'w').write('a,b\\n1,2\\n')
+        open('blob.bin', 'wb').write(bytes.fromhex('{payload_hex}'))
+        print('wrote files')
+        """
+    )
+    res = runner.run_code(code, "python", ws)
+    names = {a["name"] for a in res.artifacts}
+    check("produced text file detected as artifact", "produced/out.csv" in names, str(names))
+    check("produced binary file detected as artifact", "blob.bin" in names, str(names))
+    out_csv = ws / "produced" / "out.csv"
+    check("text artifact synced to local workspace with correct content",
+          out_csv.exists() and out_csv.read_text(encoding="utf-8") == "a,b\n1,2\n")
+    blob = ws / "blob.bin"
+    check("binary artifact round-tripped byte-for-byte",
+          blob.exists() and blob.read_bytes() == bytes.fromhex(payload_hex),
+          f"{blob.stat().st_size if blob.exists() else 'missing'} bytes")
+
+    # ---------------------------------------------------------------- #
+    section("6. interpreter system files are NOT dragged into the workspace")
+    # ---------------------------------------------------------------- #
+    for junk in ("node_modules", "package.json", "package-lock.json", ".ipython"):
+        check(f"workspace clean of '{junk}'", not (ws / junk).exists())
+
+    # ---------------------------------------------------------------- #
+    section("7. unchanged input is not re-flagged as an artifact")
+    # ---------------------------------------------------------------- #
+    res = runner.run_code("print('noop')", "python", ws)
+    names = {a["name"] for a in res.artifacts}
+    check("unchanged out.csv not re-reported as artifact", "produced/out.csv" not in names, str(names))
+
+    # ---------------------------------------------------------------- #
+    section("8. session is reused across runs")
+    # ---------------------------------------------------------------- #
+    sid_now = runner._sessions.get(ws.name)
+    check("same session reused (no per-call session churn)", sid_now == sid0,
+          f"start={sid0} now={sid_now}")
+
+    # ---------------------------------------------------------------- #
+    section("9. close_session tears the session down deterministically")
+    # ---------------------------------------------------------------- #
+    runner.close_session(ws)
+    check("session removed from runner map", ws.name not in runner._sessions)
+    runner.run_code("print('after close')", "python", ws)   # lazily opens a NEW session
+    sid_new = runner._sessions.get(ws.name)
+    check("next run opens a fresh session", bool(sid_new) and sid_new != sid0,
+          f"old={sid0} new={sid_new}")
+
+    # ---------------------------------------------------------------- #
+    if not args.skip_node:
+        section("10. run_code(node) — JavaScript runtime")
+        res = runner.run_code("console.log('node ' + (1+2))", "node", ws)
+        check("run_code(node) ran and printed", "node 3" in res.stdout, repr(res.stdout[:160]))
+
+    # ---------------------------------------------------------------- #
+    section("11. (optional) real tool layer via ToolContext")
+    # ---------------------------------------------------------------- #
+    _optional_tool_layer(runner, ws)
+
+    return _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
+
+
+def _optional_config_dispatch(tmp: Path, args: argparse.Namespace) -> None:
+    """If the full backend deps are present, verify config selection + get_runner().
+
+    Wrapped whole (imports *and* calls) because some app modules import heavy deps like
+    sqlalchemy lazily at call time, not import time.
+    """
     data_dir = tmp / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
     cfg_path = tmp / "config.yml"
@@ -101,168 +254,43 @@ def main() -> int:
     )
     os.environ["PHLOX_CONFIG"] = str(cfg_path)
     os.environ["PHLOX_DATA"] = str(data_dir)
-    if args.profile:
-        os.environ["AWS_PROFILE"] = args.profile
-    os.environ.setdefault("AWS_REGION", args.region)
-
-    # Make `app` importable when run from the repo root.
-    backend = Path(__file__).resolve().parent.parent / "backend"
-    sys.path.insert(0, str(backend))
-
-    # ---- Imports (after env setup) ----
-    from app.agent.tools.base import ToolContext
-    from app.agent.tools.code import ExecuteNode, ExecutePython
-    from app.agent.tools.fs import ListDir, ReadFile, WriteFile
-    from app.agent.tools.shell import RunShell
-    from app.config import get_sandbox_config
-    from app.sandbox.runner import (
-        AgentCoreCodeInterpreterRunner,
-        get_runner,
-        reset_runner,
-    )
-    from app.workspace.manager import workspace_dir
-
-    print(f"region={args.region!r} profile={args.profile!r} identifier={args.identifier!r}")
-    print(f"temp data dir: {data_dir}")
-
-    # ---------------------------------------------------------------- #
-    section("1. Config + get_runner() dispatch")
-    # ---------------------------------------------------------------- #
-    cfg = get_sandbox_config()
-    check("config selects runner=agentcore", cfg.get("runner") == "agentcore", cfg.get("runner"))
-    check("config has agentcore defaults",
-          cfg.get("agentcore", {}).get("identifier") == args.identifier
-          and cfg["agentcore"].get("session_timeout_seconds") == 900,
-          str(cfg.get("agentcore")))
-
-    reset_runner()
-    runner = get_runner()
-    is_agentcore = isinstance(runner, AgentCoreCodeInterpreterRunner)
-    check("get_runner() returns AgentCoreCodeInterpreterRunner", is_agentcore, type(runner).__name__)
-    if not is_agentcore:
-        print("\nABORT: runner is not the AgentCore runner; nothing else can be validated.")
-        return 1
-
-    conv_id = f"e2e-agentcore-{os.getpid()}"
-    ws = workspace_dir(conv_id)
-    ctx = ToolContext(conversation_id=conv_id, workspace=ws, db=None, runner=runner)
-
-    # ---------------------------------------------------------------- #
-    section("2. Preflight: real AWS session (defeats silent local fallback)")
-    # ---------------------------------------------------------------- #
-    # _session_for is OUTSIDE _run's try/except, so an AWS error raises here loudly
-    # instead of being swallowed by the fallback-to-local path.
     try:
-        sid0 = runner._session_for(ws)
-        check("opened a live Code Interpreter session", bool(sid0), f"sessionId={sid0}")
+        from app.config import get_sandbox_config
+        from app.sandbox.runner import (
+            AgentCoreCodeInterpreterRunner,
+            get_runner,
+            reset_runner,
+        )
+
+        cfg = get_sandbox_config()
+        check("config selects runner=agentcore", cfg.get("runner") == "agentcore", str(cfg.get("runner")))
+        check("config has agentcore defaults",
+              cfg.get("agentcore", {}).get("identifier") == args.identifier
+              and cfg["agentcore"].get("session_timeout_seconds") == 900,
+              str(cfg.get("agentcore")))
+        reset_runner()
+        r = get_runner()
+        check("get_runner() returns AgentCoreCodeInterpreterRunner",
+              isinstance(r, AgentCoreCodeInterpreterRunner), type(r).__name__)
+        reset_runner()
     except Exception as exc:  # noqa: BLE001
-        check("opened a live Code Interpreter session", False, f"{type(exc).__name__}: {exc}")
-        print("\nABORT: could not reach AgentCore. Check credentials, region, and IAM:")
-        print("  bedrock-agentcore:StartCodeInterpreterSession / InvokeCodeInterpreter / StopCodeInterpreterSession")
-        traceback.print_exc()
-        _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
-        return 1
+        print(f"(skipped — full backend deps not available: {type(exc).__name__}: {exc})")
+        print("  The core runner checks below still fully validate the feature. To enable")
+        print("  this section, run with the backend venv (e.g. `pip install -e ./backend`).")
 
-    def assert_remote_path(label: str) -> None:
-        """After any tool run, the session map must be populated — else we fell back to local."""
-        check(f"{label}: ran on AWS (not local fallback)", ws.name in runner._sessions,
-              f"sessions={list(runner._sessions)}")
 
-    # ---------------------------------------------------------------- #
-    section("3. execute_python — stdout / exit / structuredContent")
-    # ---------------------------------------------------------------- #
-    r = ExecutePython().run(ctx, code="print('hello from agentcore')")
-    check("stdout captured", "hello from agentcore" in r.content, repr(r.content[:120]))
-    check("exit 0 -> not is_error", r.is_error is False)
-    assert_remote_path("execute_python")
+def _optional_tool_layer(runner, ws: Path) -> None:
+    """If the tool classes are importable (need sqlalchemy etc.), drive one via ToolContext."""
+    try:
+        from app.agent.tools.base import ToolContext
+        from app.agent.tools.code import ExecutePython
 
-    r = ExecutePython().run(ctx, code="raise SystemExit(5)")
-    check("nonzero exit -> is_error", r.is_error is True, repr(r.content[:160]))
-
-    # ---------------------------------------------------------------- #
-    section("4. run_shell — command + CRLF normalization")
-    # ---------------------------------------------------------------- #
-    r = RunShell().run(ctx, command="echo shell-works && pwd")
-    check("run_shell stdout captured", "shell-works" in r.content, repr(r.content[:160]))
-    check("CRLF normalized to \\n (no stray \\r)", "\r" not in r.content)
-
-    # ---------------------------------------------------------------- #
-    section("5. sync IN — a local file is visible to the session")
-    # ---------------------------------------------------------------- #
-    WriteFile().run(ctx, path="input.txt", content="payload-12345")
-    r = ExecutePython().run(ctx, code="print(open('input.txt').read())")
-    check("local file synced into session", "payload-12345" in r.content, repr(r.content[:160]))
-
-    # ---------------------------------------------------------------- #
-    section("6. sync OUT — produced files (text + binary) come back as artifacts")
-    # ---------------------------------------------------------------- #
-    payload_hex = "89504e470d0a1a0aff00fe01"   # non-UTF-8 bytes -> exercises the blob path
-    code = textwrap.dedent(
-        f"""
-        import os
-        os.makedirs('produced', exist_ok=True)
-        open('produced/out.csv', 'w').write('a,b\\n1,2\\n')
-        open('blob.bin', 'wb').write(bytes.fromhex('{payload_hex}'))
-        print('wrote files')
-        """
-    )
-    r = ExecutePython().run(ctx, code=code)
-    names = {a["name"] for a in r.artifacts}
-    check("produced text file detected as artifact", "produced/out.csv" in names, str(names))
-    check("produced binary file detected as artifact", "blob.bin" in names, str(names))
-    out_csv = ws / "produced" / "out.csv"
-    check("text artifact synced to local workspace with correct content",
-          out_csv.exists() and out_csv.read_text(encoding="utf-8") == "a,b\n1,2\n")
-    blob = ws / "blob.bin"
-    check("binary artifact round-tripped byte-for-byte",
-          blob.exists() and blob.read_bytes() == bytes.fromhex(payload_hex),
-          f"{blob.stat().st_size if blob.exists() else 'missing'} bytes")
-
-    # read_file (a pure local tool) sees the produced file -> local dir is authoritative.
-    r = ReadFile().run(ctx, path="produced/out.csv")
-    check("read_file (local tool) sees the produced file", "a,b" in r.content)
-
-    # ---------------------------------------------------------------- #
-    section("7. interpreter system files are NOT dragged into the workspace")
-    # ---------------------------------------------------------------- #
-    for junk in ("node_modules", "package.json", "package-lock.json", ".ipython"):
-        check(f"workspace clean of '{junk}'", not (ws / junk).exists())
-    r = ListDir().run(ctx, path=".")
-    check("list_dir shows our files, not interpreter internals",
-          "input.txt" in r.content and "node_modules" not in r.content, repr(r.content[:200]))
-
-    # ---------------------------------------------------------------- #
-    section("8. unchanged input is not re-flagged as an artifact")
-    # ---------------------------------------------------------------- #
-    r = ExecutePython().run(ctx, code="print('noop')")
-    names = {a["name"] for a in r.artifacts}
-    check("unchanged out.csv not re-reported as artifact", "produced/out.csv" not in names, str(names))
-
-    # ---------------------------------------------------------------- #
-    section("9. session is reused across runs")
-    # ---------------------------------------------------------------- #
-    sid_now = runner._sessions.get(ws.name)
-    check("same session reused (no per-call session churn)", sid_now == sid0,
-          f"start={sid0} now={sid_now}")
-
-    # ---------------------------------------------------------------- #
-    section("10. close_session tears the session down deterministically")
-    # ---------------------------------------------------------------- #
-    runner.close_session(ws)
-    check("session removed from runner map", ws.name not in runner._sessions)
-    # A subsequent run lazily opens a NEW session (different id).
-    ExecutePython().run(ctx, code="print('after close')")
-    sid_new = runner._sessions.get(ws.name)
-    check("next run opens a fresh session", bool(sid_new) and sid_new != sid0,
-          f"old={sid0} new={sid_new}")
-
-    # ---------------------------------------------------------------- #
-    if not args.skip_node:
-        section("11. execute_node — JavaScript runtime")
-        r = ExecuteNode().run(ctx, code="console.log('node ' + (1+2))")
-        check("execute_node ran and printed", "node 3" in r.content, repr(r.content[:160]))
-
-    return _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
+        ctx = ToolContext(conversation_id=ws.name, workspace=ws, db=None, runner=runner)
+        result = ExecutePython().run(ctx, code="print('tool-layer ok')")
+        check("execute_python tool runs through ToolContext + runner",
+              "tool-layer ok" in result.content and result.is_error is False, repr(result.content[:120]))
+    except Exception as exc:  # noqa: BLE001
+        print(f"(skipped — tool layer not available: {type(exc).__name__}: {exc})")
 
 
 def _summary_and_cleanup(runner, ws, tmp: Path, keep: bool) -> int:

--- a/scripts/e2e_agentcore.py
+++ b/scripts/e2e_agentcore.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""End-to-end test for the AgentCore Code Interpreter sandbox runner (live AWS).
+
+Drives the feature through Phlox's **own** code paths — config selection, ``get_runner()``,
+the real ``execute_python`` / ``execute_node`` / ``run_shell`` / ``write_file`` /
+``read_file`` tools via a ``ToolContext``, and ``close_session`` — against a real AWS
+Bedrock AgentCore Code Interpreter. It proves the whole integration the agent relies on,
+without needing an LLM provider or the HTTP server.
+
+It deliberately defeats the runner's silent local fallback: it preflights a real session
+(failing loudly if AWS is misconfigured) and asserts after every run that the remote
+session map is populated — so a green result genuinely means AWS executed the code, not
+that we quietly ran locally.
+
+Prereqs:
+  - Run with the backend venv active (needs Phlox deps: boto3, sqlalchemy, pyyaml, ...).
+  - AWS credentials in the environment (env / shared config / SSO / role), and a region
+    where Code Interpreter is enabled.
+  - IAM: bedrock-agentcore:StartCodeInterpreterSession, :InvokeCodeInterpreter,
+         :StopCodeInterpreterSession.
+
+Usage:
+  python scripts/e2e_agentcore.py --region us-west-2
+  python scripts/e2e_agentcore.py --region us-west-2 --profile my-profile
+  python scripts/e2e_agentcore.py --region us-west-2 --keep      # don't delete workspace
+  python scripts/e2e_agentcore.py --region us-west-2 --skip-node # skip the Node check
+
+Exit code 0 = every check passed; 1 = a check failed (or AWS was unreachable).
+It writes only to a throwaway temp PHLOX_DATA dir and tears the session down at the end,
+so it does not touch your real Phlox data or leak AWS sessions.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+import textwrap
+import traceback
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Tiny check harness
+# --------------------------------------------------------------------------- #
+_RESULTS: list[tuple[bool, str, str]] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> bool:
+    _RESULTS.append((bool(ok), name, detail))
+    mark = "PASS" if ok else "FAIL"
+    line = f"[{mark}] {name}"
+    if detail:
+        line += f"  — {detail}"
+    print(line, flush=True)
+    return bool(ok)
+
+
+def section(title: str) -> None:
+    print("\n" + "=" * 72 + f"\n## {title}\n" + "=" * 72, flush=True)
+
+
+# --------------------------------------------------------------------------- #
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Live E2E for the AgentCore sandbox runner.")
+    ap.add_argument("--region", default=os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION"))
+    ap.add_argument("--profile", default=os.environ.get("AWS_PROFILE"))
+    ap.add_argument("--identifier", default="aws.codeinterpreter.v1")
+    ap.add_argument("--skip-node", action="store_true", help="skip the execute_node check")
+    ap.add_argument("--keep", action="store_true", help="keep the temp workspace/data dir")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.region:
+        print("ERROR: no region. Pass --region or set AWS_REGION.", file=sys.stderr)
+        return 2
+
+    # ---- Isolate Phlox config + data to a throwaway dir, selecting the agentcore
+    #      runner, BEFORE importing any app module (app.config reads env at import). ----
+    tmp = Path(tempfile.mkdtemp(prefix="phlox-e2e-agentcore-"))
+    data_dir = tmp / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    cfg_path = tmp / "config.yml"
+    profile_line = f"    profile: {args.profile}\n" if args.profile else ""
+    cfg_path.write_text(
+        textwrap.dedent(
+            f"""\
+            auth:
+              enabled: false
+            sandbox:
+              runner: agentcore
+              agentcore:
+                identifier: {args.identifier}
+                region: {args.region}
+            """
+        )
+        + profile_line,
+        encoding="utf-8",
+    )
+    os.environ["PHLOX_CONFIG"] = str(cfg_path)
+    os.environ["PHLOX_DATA"] = str(data_dir)
+    if args.profile:
+        os.environ["AWS_PROFILE"] = args.profile
+    os.environ.setdefault("AWS_REGION", args.region)
+
+    # Make `app` importable when run from the repo root.
+    backend = Path(__file__).resolve().parent.parent / "backend"
+    sys.path.insert(0, str(backend))
+
+    # ---- Imports (after env setup) ----
+    from app.agent.tools.base import ToolContext
+    from app.agent.tools.code import ExecuteNode, ExecutePython
+    from app.agent.tools.fs import ListDir, ReadFile, WriteFile
+    from app.agent.tools.shell import RunShell
+    from app.config import get_sandbox_config
+    from app.sandbox.runner import (
+        AgentCoreCodeInterpreterRunner,
+        get_runner,
+        reset_runner,
+    )
+    from app.workspace.manager import workspace_dir
+
+    print(f"region={args.region!r} profile={args.profile!r} identifier={args.identifier!r}")
+    print(f"temp data dir: {data_dir}")
+
+    # ---------------------------------------------------------------- #
+    section("1. Config + get_runner() dispatch")
+    # ---------------------------------------------------------------- #
+    cfg = get_sandbox_config()
+    check("config selects runner=agentcore", cfg.get("runner") == "agentcore", cfg.get("runner"))
+    check("config has agentcore defaults",
+          cfg.get("agentcore", {}).get("identifier") == args.identifier
+          and cfg["agentcore"].get("session_timeout_seconds") == 900,
+          str(cfg.get("agentcore")))
+
+    reset_runner()
+    runner = get_runner()
+    is_agentcore = isinstance(runner, AgentCoreCodeInterpreterRunner)
+    check("get_runner() returns AgentCoreCodeInterpreterRunner", is_agentcore, type(runner).__name__)
+    if not is_agentcore:
+        print("\nABORT: runner is not the AgentCore runner; nothing else can be validated.")
+        return 1
+
+    conv_id = f"e2e-agentcore-{os.getpid()}"
+    ws = workspace_dir(conv_id)
+    ctx = ToolContext(conversation_id=conv_id, workspace=ws, db=None, runner=runner)
+
+    # ---------------------------------------------------------------- #
+    section("2. Preflight: real AWS session (defeats silent local fallback)")
+    # ---------------------------------------------------------------- #
+    # _session_for is OUTSIDE _run's try/except, so an AWS error raises here loudly
+    # instead of being swallowed by the fallback-to-local path.
+    try:
+        sid0 = runner._session_for(ws)
+        check("opened a live Code Interpreter session", bool(sid0), f"sessionId={sid0}")
+    except Exception as exc:  # noqa: BLE001
+        check("opened a live Code Interpreter session", False, f"{type(exc).__name__}: {exc}")
+        print("\nABORT: could not reach AgentCore. Check credentials, region, and IAM:")
+        print("  bedrock-agentcore:StartCodeInterpreterSession / InvokeCodeInterpreter / StopCodeInterpreterSession")
+        traceback.print_exc()
+        _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
+        return 1
+
+    def assert_remote_path(label: str) -> None:
+        """After any tool run, the session map must be populated — else we fell back to local."""
+        check(f"{label}: ran on AWS (not local fallback)", ws.name in runner._sessions,
+              f"sessions={list(runner._sessions)}")
+
+    # ---------------------------------------------------------------- #
+    section("3. execute_python — stdout / exit / structuredContent")
+    # ---------------------------------------------------------------- #
+    r = ExecutePython().run(ctx, code="print('hello from agentcore')")
+    check("stdout captured", "hello from agentcore" in r.content, repr(r.content[:120]))
+    check("exit 0 -> not is_error", r.is_error is False)
+    assert_remote_path("execute_python")
+
+    r = ExecutePython().run(ctx, code="raise SystemExit(5)")
+    check("nonzero exit -> is_error", r.is_error is True, repr(r.content[:160]))
+
+    # ---------------------------------------------------------------- #
+    section("4. run_shell — command + CRLF normalization")
+    # ---------------------------------------------------------------- #
+    r = RunShell().run(ctx, command="echo shell-works && pwd")
+    check("run_shell stdout captured", "shell-works" in r.content, repr(r.content[:160]))
+    check("CRLF normalized to \\n (no stray \\r)", "\r" not in r.content)
+
+    # ---------------------------------------------------------------- #
+    section("5. sync IN — a local file is visible to the session")
+    # ---------------------------------------------------------------- #
+    WriteFile().run(ctx, path="input.txt", content="payload-12345")
+    r = ExecutePython().run(ctx, code="print(open('input.txt').read())")
+    check("local file synced into session", "payload-12345" in r.content, repr(r.content[:160]))
+
+    # ---------------------------------------------------------------- #
+    section("6. sync OUT — produced files (text + binary) come back as artifacts")
+    # ---------------------------------------------------------------- #
+    payload_hex = "89504e470d0a1a0aff00fe01"   # non-UTF-8 bytes -> exercises the blob path
+    code = textwrap.dedent(
+        f"""
+        import os
+        os.makedirs('produced', exist_ok=True)
+        open('produced/out.csv', 'w').write('a,b\\n1,2\\n')
+        open('blob.bin', 'wb').write(bytes.fromhex('{payload_hex}'))
+        print('wrote files')
+        """
+    )
+    r = ExecutePython().run(ctx, code=code)
+    names = {a["name"] for a in r.artifacts}
+    check("produced text file detected as artifact", "produced/out.csv" in names, str(names))
+    check("produced binary file detected as artifact", "blob.bin" in names, str(names))
+    out_csv = ws / "produced" / "out.csv"
+    check("text artifact synced to local workspace with correct content",
+          out_csv.exists() and out_csv.read_text(encoding="utf-8") == "a,b\n1,2\n")
+    blob = ws / "blob.bin"
+    check("binary artifact round-tripped byte-for-byte",
+          blob.exists() and blob.read_bytes() == bytes.fromhex(payload_hex),
+          f"{blob.stat().st_size if blob.exists() else 'missing'} bytes")
+
+    # read_file (a pure local tool) sees the produced file -> local dir is authoritative.
+    r = ReadFile().run(ctx, path="produced/out.csv")
+    check("read_file (local tool) sees the produced file", "a,b" in r.content)
+
+    # ---------------------------------------------------------------- #
+    section("7. interpreter system files are NOT dragged into the workspace")
+    # ---------------------------------------------------------------- #
+    for junk in ("node_modules", "package.json", "package-lock.json", ".ipython"):
+        check(f"workspace clean of '{junk}'", not (ws / junk).exists())
+    r = ListDir().run(ctx, path=".")
+    check("list_dir shows our files, not interpreter internals",
+          "input.txt" in r.content and "node_modules" not in r.content, repr(r.content[:200]))
+
+    # ---------------------------------------------------------------- #
+    section("8. unchanged input is not re-flagged as an artifact")
+    # ---------------------------------------------------------------- #
+    r = ExecutePython().run(ctx, code="print('noop')")
+    names = {a["name"] for a in r.artifacts}
+    check("unchanged out.csv not re-reported as artifact", "produced/out.csv" not in names, str(names))
+
+    # ---------------------------------------------------------------- #
+    section("9. session is reused across runs")
+    # ---------------------------------------------------------------- #
+    sid_now = runner._sessions.get(ws.name)
+    check("same session reused (no per-call session churn)", sid_now == sid0,
+          f"start={sid0} now={sid_now}")
+
+    # ---------------------------------------------------------------- #
+    section("10. close_session tears the session down deterministically")
+    # ---------------------------------------------------------------- #
+    runner.close_session(ws)
+    check("session removed from runner map", ws.name not in runner._sessions)
+    # A subsequent run lazily opens a NEW session (different id).
+    ExecutePython().run(ctx, code="print('after close')")
+    sid_new = runner._sessions.get(ws.name)
+    check("next run opens a fresh session", bool(sid_new) and sid_new != sid0,
+          f"old={sid0} new={sid_new}")
+
+    # ---------------------------------------------------------------- #
+    if not args.skip_node:
+        section("11. execute_node — JavaScript runtime")
+        r = ExecuteNode().run(ctx, code="console.log('node ' + (1+2))")
+        check("execute_node ran and printed", "node 3" in r.content, repr(r.content[:160]))
+
+    return _summary_and_cleanup(runner, ws, tmp, keep=args.keep)
+
+
+def _summary_and_cleanup(runner, ws, tmp: Path, keep: bool) -> int:
+    section("Cleanup")
+    try:
+        runner.close_session(ws)
+        print("closed session (if any).")
+    except Exception as exc:  # noqa: BLE001
+        print(f"close_session during cleanup failed: {exc}")
+    if keep:
+        print(f"kept temp dir: {tmp}")
+    else:
+        shutil.rmtree(tmp, ignore_errors=True)
+        print(f"removed temp dir: {tmp}")
+
+    passed = sum(1 for ok, _, _ in _RESULTS if ok)
+    failed = [name for ok, name, _ in _RESULTS if not ok]
+    section("Summary")
+    print(f"{passed}/{len(_RESULTS)} checks passed")
+    if failed:
+        print("FAILED:")
+        for name in failed:
+            print(f"  - {name}")
+        print("\nRESULT: ❌ FAIL")
+        return 1
+    print("\nRESULT: ✅ ALL CHECKS PASSED — feature works end-to-end against live AWS.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds an optional **remote** sandbox backend so agent-generated code can run **off-host**, and ships **AWS Bedrock AgentCore Code Interpreter** (a managed Firecracker microVM) as the first remote runner. Strictly additive and non-breaking — `local` stays the default and `local`/`container` behavior is unchanged.

Today both runners execute agent code on the Phlox host: `LocalSubprocessRunner` runs it as the Phlox process, and `ContainerRunner` shares the host kernel. A managed remote sandbox runs untrusted code off-host with **kernel-level isolation** — a real upgrade for hosted/multi-user Phlox — and the abstraction generalizes to any provider (E2B, Modal, Daytona, remote Docker, …).