### PR TITLE
Added artifact canvas viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ models).
 - 🤝 **Human-in-the-loop approvals** — pause on sensitive tools, approve/deny, resume.
 - 🧰 **Code execution** with captured output and **artifacts** shown inline + a
   **Workspace Files** panel to browse/download everything the agent created.
+- 🖥️ **Artifact canvas** — HTML and Markdown files the agent writes open in a live,
+  resizable side panel (sandboxed preview + raw-source toggle) instead of a plain download.
 - 🗂️ **Workspace checkpoints** — git-backed snapshots with one-click restore.
 - 📚 **Documents / RAG** — upload PDF/DOCX/TXT/MD/code; explicitly search the document
   library per prompt, attach documents to a specific message, or reference existing

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1087,7 +1087,7 @@ requires-dist = [
     { name = "ddgs", specifier = ">=9.14.4" },
     { name = "fastapi", specifier = ">=0.135.0" },
     { name = "httpx", specifier = ">=0.28.0" },
-    { name = "mcp", specifier = ">=1.2.0" },
+    { name = "mcp", specifier = ">=1.8.0" },
     { name = "numpy", specifier = ">=2.1.0" },
     { name = "openai", specifier = ">=2.26.0" },
     { name = "pydantic", specifier = ">=2.10.0" },

--- a/docs/ADDING_A_TOOL.md
+++ b/docs/ADDING_A_TOOL.md
@@ -43,7 +43,10 @@ class WordCount(Tool):
 ### `ToolResult` fields
 - `content: str` — text the model sees (keep it bounded; large outputs get truncated)
 - `artifacts: list[dict]` — files to surface to the UI, each
-  `{name, path, ext, size}` **relative to the workspace** (the harness adds the URL)
+  `{name, path, ext, size}` **relative to the workspace** (the harness adds the URL).
+  `.html`/`.htm` and `.md`/`.markdown` artifacts auto-open in the live **artifact canvas**
+  (`frontend/src/utils/canvas.js::canvasKind`); other non-binary extensions get a
+  plain-text canvas preview; images and known binary formats stay download-only.
 - `is_error: bool`
 
 Rules of thumb: **stay inside the workspace** (use `resolve_in_workspace`); never block

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,12 +177,32 @@ deals with provider-specific shapes.
 | **Theme** | `theme/tokens.css`, `presets.js` | CSS-variable token layer + theme catalog (FH default) |
 | **Layout** | `components/layout/Header.jsx`, `Sidebar.jsx` | FH logo header, conversation list, nav |
 | **Chat** | `components/chat/*` | `Message`, `ToolCallCard`, `ArtifactViewer`, `Composer`; `pages/ChatPage.jsx` |
+| **Canvas** | `components/canvas/CanvasPanel.jsx`, `utils/canvas.js` | Side-panel live preview of html/markdown/text artifacts (see below) |
 | **Markdown** | `components/markdown/Markdown.jsx` | react-markdown + GFM + syntax highlight + copy |
 | **Settings** | `components/settings/*`, `documents/*`, `mcp/*`, `tools/*` | Drawer with user tabs (Model, Appearance, Documents, Memory, API Keys) + admin tabs (Users, Usage & Cost, **Budgets**, **Configuration**, Authentication, MCP, Tools) |
 
 The frontend renders a rich turn: collapsible **tool cards** (args + results), a
 **reasoning** disclosure, inline **artifacts** (images render, files download), and
 streamed markdown with highlighted, copyable code.
+
+### Artifact canvas
+Files the agent writes (`write_file`/`edit_file`/code-exec output) are classified by
+extension in `utils/canvas.js` (`canvasKind`): `.html`/`.htm` → **html**,
+`.md`/`.markdown` → **markdown**, any other non-binary extension → **code** (plain-text
+preview); images and known binary formats (pdf, zip, docx, …) are excluded and stay
+download-only. The store (`useStore.js`) auto-opens `CanvasPanel` the first time an
+eligible `artifact` SSE event arrives in a turn, and re-fetches in place if the agent
+rewrites the same path later in the same turn; a different path never yanks the panel
+away from what the user is looking at — they switch via the "View" (eye icon) button on
+an artifact chip or in the Workspace Files modal. `CanvasPanel` fetches the raw file text
+itself (`api.getFileText`, a plain authenticated `fetch`, not an `<img>`/`<iframe src>`
+load) because `/api/files/<conv>` sends `Content-Disposition: attachment`, which browsers
+refuse to render inline in a frame. HTML previews render via
+`<iframe sandbox="allow-scripts allow-forms allow-popups allow-modals" srcDoc={text}>` —
+omitting `allow-same-origin` keeps the preview in an opaque, cross-origin sandbox: scripts
+in agent-generated pages run, but can't read the parent app's cookies/storage/DOM. Both
+html and markdown have a Preview/Source toggle; the panel width is user-resizable via a
+drag handle on its left edge.
 
 ## 5. Data model (SQLite, `models.py`)
 
@@ -261,3 +281,6 @@ Quick end-to-end checks that the foundation passed (reproduce any of these):
   `search_documents` returns the matching chunk.
 - Artifacts: ask Python to write `data.csv` → an `artifact` event + downloadable file at
   `/api/files/<conv>?path=data.csv`.
+- Artifact canvas: ask the agent to `write_file` an `.html` or `.md` file → the canvas
+  panel auto-opens with a live preview (Preview/Source toggle for html); the "View" button
+  on an artifact chip or in the Workspace Files modal reopens any prior one.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,7 +150,16 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
   Markdown. _Implemented in:_ `Sidebar.jsx`, store `exportConversation`.
 - [x] **Richer artifacts.** **Mermaid** diagrams + **KaTeX** math in markdown; image
   **lightbox**. _Implemented in:_ `markdown/Markdown.jsx`, `markdown/Mermaid.jsx`,
-  `chat/ArtifactViewer.jsx`. (HTML/React live preview still TODO.)
+  `chat/ArtifactViewer.jsx`.
+- [x] **Artifact canvas.** HTML/Markdown/text artifacts open in a resizable, live-updating
+  side panel instead of just a download — HTML renders in a sandboxed `<iframe srcDoc>`
+  (`allow-scripts`, no `allow-same-origin`, so generated pages can't reach the app's
+  session), with a Preview/Source toggle for html + markdown. Auto-opens on the first
+  eligible artifact per turn; a "View" button on artifact chips and in the Workspace Files
+  modal opens any other one. _Implemented in:_ `utils/canvas.js`,
+  `components/canvas/CanvasPanel.jsx`, store `canvas`/`openCanvasArtifact`/`closeCanvas`,
+  `ArtifactViewer.jsx`, `WorkspaceFilesModal.jsx`. (React/JSX live preview — i.e. compiling
+  a component artifact, not just static html — still TODO.)
 - [x] **Prompt caching.** Bedrock cache points on the system prompt + tool defs
   (opt-in `prompt_cache: true` per profile; Claude models). OpenAI auto-caches.
   _Implemented in:_ `providers/bedrock_provider.py`.
@@ -189,7 +198,7 @@ Deferred until the app is used with real/sensitive data. **Gates any PHI use.**
 
 ### Status
 **Tiers 1, 2, 3, and 4 are complete.** Remaining Tier 4 nice-to-haves: full
-conversation-branch tree, HTML/React live artifact previews, command palette, voice.
+conversation-branch tree, React/JSX live artifact previews, command palette, voice.
 **API gateway Phase 1 is complete; Phase 2 (`/v1/agent/completions`) is next.**
 **Postgres and PHI/data-governance are Tier 5**, deferred until a sensitive-data
 deployment.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Sidebar from './components/layout/Sidebar'
 import Header from './components/layout/Header'
 import ChatPage from './pages/ChatPage'
 import LoginScreen from './components/auth/LoginScreen'
+import CanvasPanel from './components/canvas/CanvasPanel'
 import { useStore } from './store/useStore'
 
 // Lazy-loaded: the settings drawer pulls in the admin/user management UI and is only
@@ -16,6 +17,7 @@ export default function App() {
   const authConfig = useStore((s) => s.authConfig)
   const user = useStore((s) => s.user)
   const newConversation = useStore((s) => s.newConversation)
+  const canvas = useStore((s) => s.canvas)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState('providers')
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -39,6 +41,7 @@ export default function App() {
         setSidebarOpen((v) => !v)
       } else if (e.key === 'Escape') {
         setSettingsOpen(false)
+        useStore.getState().closeCanvas()
       }
     }
     window.addEventListener('keydown', onKey)
@@ -68,6 +71,7 @@ export default function App() {
         />
         <ChatPage onOpenSettings={openSettings} />
       </div>
+      {canvas && <CanvasPanel />}
       {settingsOpen && (
         <Suspense fallback={null}>
           <SettingsDrawer initialTab={settingsTab} onClose={() => setSettingsOpen(false)} />

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -113,4 +113,10 @@ export const api = {
   fileUrl: (conversationId, path) =>
     `/api/files/${conversationId}?path=${encodeURIComponent(path)}`,
   listWorkspaceFiles: (conversationId) => req('GET', `/api/files/${conversationId}/list`),
+  // Raw text content of a workspace file, for the artifact canvas preview.
+  getFileText: async (conversationId, path) => {
+    const res = await fetch(api.fileUrl(conversationId, path), { headers: { ...authHeaders() } })
+    if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`)
+    return res.text()
+  },
 }

--- a/frontend/src/components/canvas/CanvasPanel.jsx
+++ b/frontend/src/components/canvas/CanvasPanel.jsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Code2, Download, ExternalLink, FileText, Loader2, RefreshCw, X, Eye } from 'lucide-react'
+import { api } from '../../api/client'
+import { useStore } from '../../store/useStore'
+import Markdown from '../markdown/Markdown'
+
+const MIN_WIDTH = 340
+const MAX_WIDTH = 960
+const DEFAULT_WIDTH = 480
+
+const KIND_ICON = { html: Code2, markdown: FileText, code: FileText }
+const KIND_LABEL = { html: 'HTML', markdown: 'Markdown', code: 'Text' }
+
+// Drag handle on the left edge of the panel to resize it.
+function useResize(width, setWidth) {
+  const dragging = useRef(false)
+  const onMouseDown = useCallback((e) => {
+    e.preventDefault()
+    dragging.current = true
+    document.body.style.cursor = 'col-resize'
+  }, [])
+  useEffect(() => {
+    const onMove = (e) => {
+      if (!dragging.current) return
+      const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, window.innerWidth - e.clientX))
+      setWidth(next)
+    }
+    const onUp = () => {
+      dragging.current = false
+      document.body.style.cursor = ''
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [setWidth])
+  return onMouseDown
+}
+
+export default function CanvasPanel() {
+  const canvas = useStore((s) => s.canvas)
+  const closeCanvas = useStore((s) => s.closeCanvas)
+  const [width, setWidth] = useState(DEFAULT_WIDTH)
+  const [text, setText] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [view, setView] = useState('preview') // 'preview' | 'source' — html only
+  const onDragStart = useResize(width, setWidth)
+
+  const load = useCallback(() => {
+    if (!canvas) return
+    setLoading(true)
+    setError(null)
+    api
+      .getFileText(canvas.conversationId, canvas.path)
+      .then(setText)
+      .catch((e) => setError(String(e.message || e)))
+      .finally(() => setLoading(false))
+  }, [canvas])
+
+  useEffect(() => {
+    setView('preview')
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canvas?.conversationId, canvas?.path, canvas?.nonce])
+
+  if (!canvas) return null
+
+  const Icon = KIND_ICON[canvas.kind] || FileText
+  const rawUrl = api.fileUrl(canvas.conversationId, canvas.path)
+
+  return (
+    <div
+      className="relative flex h-full shrink-0 flex-col border-l border-border bg-surface"
+      style={{ width }}
+    >
+      <div
+        onMouseDown={onDragStart}
+        className="absolute left-0 top-0 z-10 h-full w-1.5 -translate-x-1/2 cursor-col-resize hover:bg-accent/30"
+        title="Drag to resize"
+      />
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon size={16} className="shrink-0 text-accent" />
+          <span className="truncate text-sm font-medium text-content" title={canvas.name}>
+            {canvas.name}
+          </span>
+          <span className="shrink-0 rounded bg-surface-3 px-1.5 py-0.5 text-[10px] text-muted">
+            {KIND_LABEL[canvas.kind]}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {(canvas.kind === 'html' || canvas.kind === 'markdown') && (
+            <div className="mr-1 flex rounded-md border border-border p-0.5 text-xs">
+              <button
+                onClick={() => setView('preview')}
+                className={`flex items-center gap-1 rounded px-2 py-1 ${view === 'preview' ? 'bg-accent text-accent-fg' : 'text-muted hover:text-content'}`}
+              >
+                <Eye size={12} /> Preview
+              </button>
+              <button
+                onClick={() => setView('source')}
+                className={`flex items-center gap-1 rounded px-2 py-1 ${view === 'source' ? 'bg-accent text-accent-fg' : 'text-muted hover:text-content'}`}
+              >
+                <Code2 size={12} /> Source
+              </button>
+            </div>
+          )}
+          <button onClick={load} className="rounded p-1.5 text-muted hover:bg-surface-3 hover:text-content" title="Refresh">
+            <RefreshCw size={15} />
+          </button>
+          <a
+            href={rawUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded p-1.5 text-muted hover:bg-surface-3 hover:text-content"
+            title="Open raw file in a new tab"
+          >
+            <ExternalLink size={15} />
+          </a>
+          <a
+            href={rawUrl}
+            download={canvas.name}
+            className="rounded p-1.5 text-muted hover:bg-surface-3 hover:text-content"
+            title="Download"
+          >
+            <Download size={15} />
+          </a>
+          <button onClick={closeCanvas} className="rounded p-1.5 text-muted hover:bg-surface-3 hover:text-content" title="Close">
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {loading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="animate-spin text-accent" />
+          </div>
+        ) : error ? (
+          <div className="p-4 text-sm text-red-600">Failed to load: {error}</div>
+        ) : canvas.kind === 'html' && view === 'preview' ? (
+          <iframe
+            key={canvas.nonce}
+            srcDoc={text}
+            title={canvas.name}
+            sandbox="allow-scripts allow-forms allow-popups allow-modals"
+            className="h-full w-full border-0 bg-white"
+          />
+        ) : canvas.kind === 'markdown' && view === 'preview' ? (
+          <div className="h-full overflow-y-auto p-4">
+            <Markdown>{text}</Markdown>
+          </div>
+        ) : (
+          <pre className="h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs text-content">
+            {text}
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ArtifactViewer.jsx
+++ b/frontend/src/components/chat/ArtifactViewer.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
-import { Download, FileText, Image as ImageIcon, X } from 'lucide-react'
+import { Download, Eye, FileText, Image as ImageIcon, X } from 'lucide-react'
+import { canvasKind } from '../../utils/canvas'
+import { useStore } from '../../store/useStore'
 
 const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']
 
@@ -16,17 +18,28 @@ function Lightbox({ url, name, onClose }) {
 
 export default function ArtifactViewer({ artifacts, conversationId }) {
   const [lightbox, setLightbox] = useState(null)
+  const openCanvasArtifact = useStore((s) => s.openCanvasArtifact)
   if (!artifacts || artifacts.length === 0) return null
   return (
     <div className="mt-2 flex flex-wrap gap-3">
       {artifacts.map((a, i) => {
         const url = a.url || `/api/files/${conversationId}?path=${encodeURIComponent(a.path)}`
         const isImage = IMAGE_EXTS.includes((a.ext || '').toLowerCase())
+        const viewable = !isImage && canvasKind(a.ext)
         return (
           <div key={i} className="overflow-hidden rounded-lg border border-border bg-surface-2">
             {isImage ? (
               <button onClick={() => setLightbox({ url, name: a.name })} title="Click to enlarge">
                 <img src={url} alt={a.name} className="max-h-72 max-w-xs cursor-zoom-in object-contain" />
+              </button>
+            ) : viewable ? (
+              <button
+                onClick={() => openCanvasArtifact(a, conversationId)}
+                className="flex items-center gap-2 px-3 py-4 hover:bg-surface-3"
+                title="Open in canvas"
+              >
+                <Eye size={20} className="text-accent" />
+                <span className="text-sm text-content">{a.name}</span>
               </button>
             ) : (
               <div className="flex items-center gap-2 px-3 py-4">

--- a/frontend/src/components/chat/WorkspaceFilesModal.jsx
+++ b/frontend/src/components/chat/WorkspaceFilesModal.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
-import { X, FolderOpen, Download, Image as ImageIcon, FileText, Loader2, RefreshCw } from 'lucide-react'
+import { X, FolderOpen, Download, Image as ImageIcon, FileText, Loader2, RefreshCw, Eye } from 'lucide-react'
 import { api } from '../../api/client'
+import { canvasKind } from '../../utils/canvas'
+import { useStore } from '../../store/useStore'
 
 const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']
 
@@ -13,6 +15,7 @@ function fmtSize(n) {
 export default function WorkspaceFilesModal({ conversationId, onClose }) {
   const [files, setFiles] = useState([])
   const [loading, setLoading] = useState(true)
+  const openCanvasArtifact = useStore((s) => s.openCanvasArtifact)
 
   const load = () => {
     setLoading(true)
@@ -54,11 +57,10 @@ export default function WorkspaceFilesModal({ conversationId, onClose }) {
               {files.map((f) => {
                 const url = api.fileUrl(conversationId, f.path)
                 const isImg = IMAGE_EXTS.includes((f.ext || '').toLowerCase())
+                const viewable = !isImg && canvasKind(f.ext)
                 return (
-                  <a
+                  <div
                     key={f.path}
-                    href={url}
-                    download={f.name}
                     className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2 hover:border-accent"
                   >
                     {isImg ? (
@@ -70,8 +72,19 @@ export default function WorkspaceFilesModal({ conversationId, onClose }) {
                       <div className="truncate text-sm text-content">{f.path}</div>
                       <div className="text-[11px] text-muted">{fmtSize(f.size)}</div>
                     </div>
-                    {isImg ? <ImageIcon size={15} className="text-muted" /> : <Download size={15} className="text-muted" />}
-                  </a>
+                    {viewable && (
+                      <button
+                        onClick={() => { openCanvasArtifact(f, conversationId); onClose() }}
+                        className="shrink-0 rounded p-1 text-muted hover:text-accent"
+                        title="Open in canvas"
+                      >
+                        <Eye size={15} />
+                      </button>
+                    )}
+                    <a href={url} download={f.name} className="shrink-0 rounded p-1 text-muted hover:text-accent" title="Download">
+                      {isImg ? <ImageIcon size={15} /> : <Download size={15} />}
+                    </a>
+                  </div>
                 )
               })}
             </div>

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -3,6 +3,7 @@ import { api } from '../api/client'
 import { streamChat } from '../api/sse'
 import { setToken } from '../api/token'
 import { applyTheme, initialTheme } from '../theme/presets'
+import { canvasKind } from '../utils/canvas'
 
 // Shape of the in-progress assistant turn assembled from SSE events.
 function emptyLive() {
@@ -24,6 +25,12 @@ export const useStore = create((set, get) => ({
   queued: null, // a follow-up queued while streaming {text, images, documentRefs, ...}
   lastUsage: null, // {input, output, total} token usage from the last model response
   budget: null, // monthly budget status for the signed-in user (or null when none applies)
+
+  // -- artifact canvas -------------------------------------------------------
+  // Side-panel preview of a workspace artifact (html/markdown/text), or null when closed.
+  // { conversationId, path, name, ext, kind, nonce } — `nonce` bumps to force a re-fetch
+  // when the same file is rewritten later in the same turn.
+  canvas: null,
 
   // -- auth ----------------------------------------------------------------
   authConfig: null, // {enabled, allow_registration, entra_enabled}
@@ -90,7 +97,7 @@ export const useStore = create((set, get) => ({
 
   logout() {
     setToken(null)
-    set({ user: null, conversations: [], messages: [], activeId: null, live: null })
+    set({ user: null, conversations: [], messages: [], activeId: null, live: null, canvas: null })
   },
 
   async loadConversations() {
@@ -133,16 +140,16 @@ export const useStore = create((set, get) => ({
   async selectConversation(id) {
     if (get().streaming) get().stopStreaming()
     if (!id) {
-      set({ activeId: null, messages: [], live: null })
+      set({ activeId: null, messages: [], live: null, canvas: null })
       return
     }
     const conv = await api.getConversation(id)
-    set({ activeId: id, messages: conv.messages, live: null })
+    set({ activeId: id, messages: conv.messages, live: null, canvas: null })
   },
 
   newConversation() {
     if (get().streaming) get().stopStreaming()
-    set({ activeId: null, messages: [], live: null, error: null })
+    set({ activeId: null, messages: [], live: null, error: null, canvas: null })
   },
 
   async deleteConversation(id) {
@@ -280,6 +287,7 @@ export const useStore = create((set, get) => ({
     set((s) => {
       if (!s.live) return {}
       const live = { ...s.live }
+      let canvas
       switch (ev.type) {
         case 'conversation':
           return { activeId: ev.id }
@@ -319,9 +327,21 @@ export const useStore = create((set, get) => ({
           )
           live.status = ''
           break
-        case 'artifact':
+        case 'artifact': {
           live.artifacts = [...live.artifacts, { name: ev.name, path: ev.path, ext: ev.ext, url: ev.url }]
+          // Auto-open the canvas the first time a viewable (html/markdown/text) artifact
+          // shows up; if it's already open on this same file, bump nonce to re-fetch the
+          // latest content (e.g. the agent iterated on the same file).
+          const kind = canvasKind(ev.ext)
+          if (kind) {
+            if (!s.canvas) {
+              canvas = { conversationId: s.activeId, path: ev.path, name: ev.name, ext: ev.ext, kind, nonce: Date.now() }
+            } else if (s.canvas.conversationId === s.activeId && s.canvas.path === ev.path) {
+              canvas = { ...s.canvas, nonce: Date.now() }
+            }
+          }
           break
+        }
         case 'approval_request':
           live.pendingApproval = { pendingId: ev.pending_id, calls: ev.calls }
           live.status = ''
@@ -331,8 +351,20 @@ export const useStore = create((set, get) => ({
         default:
           break
       }
-      return { live }
+      return canvas !== undefined ? { live, canvas } : { live }
     })
+  },
+
+  // Open the canvas on a workspace artifact (e.g. from the "View" button on an artifact
+  // chip, or a file in the workspace files modal). No-op for non-viewable extensions.
+  openCanvasArtifact(art, conversationId) {
+    const kind = canvasKind(art.ext)
+    if (!kind) return
+    set({ canvas: { conversationId, path: art.path, name: art.name, ext: art.ext, kind, nonce: Date.now() } })
+  },
+
+  closeCanvas() {
+    set({ canvas: null })
   },
 
   async _finalize() {

--- a/frontend/src/utils/canvas.js
+++ b/frontend/src/utils/canvas.js
@@ -1,0 +1,21 @@
+// Classifies a workspace artifact by extension so the UI knows whether/how to render it
+// in the artifact canvas (side panel preview) instead of just offering a download.
+const HTML_EXTS = ['.html', '.htm']
+const MARKDOWN_EXTS = ['.md', '.markdown']
+const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp']
+// Binary/opaque formats: no sane inline text preview, so fall back to download-only.
+const NON_TEXT_EXTS = [
+  ...IMAGE_EXTS,
+  '.pdf', '.zip', '.tar', '.gz', '.7z', '.rar', '.exe', '.bin',
+  '.sqlite', '.db', '.ico', '.woff', '.woff2', '.ttf', '.eot',
+  '.mp3', '.mp4', '.mov', '.wav', '.ogg', '.docx', '.xlsx', '.pptx',
+]
+
+// Returns 'html' | 'markdown' | 'code' (generic text preview) | null (not canvas-able).
+export function canvasKind(ext) {
+  const e = (ext || '').toLowerCase()
+  if (HTML_EXTS.includes(e)) return 'html'
+  if (MARKDOWN_EXTS.includes(e)) return 'markdown'
+  if (NON_TEXT_EXTS.includes(e)) return null
+  return 'code'
+}


### PR DESCRIPTION
**Artifact canvas** — HTML and Markdown files the agent writes open in a live, resizable side panel (sandboxed preview + raw-source toggle) instead of a plain download.