### PR TITLE
harness & security improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ e.g. Ollama's `nomic-embed-text` — so the whole stack stays offline.
 > profiles, model pricing, resilience, generation defaults, and sandbox limits **live** in
 > **Settings → (Admin) Configuration** (overrides are stored in the DB and applied
 > immediately). API keys there are write-only/masked. Bootstrap-sensitive settings (`auth`,
-> `vector_store`, the sandbox runner *type*, OTel) stay file-only and need a restart. See
-> [docs/AUTH.md](docs/AUTH.md) §admin config.
+> `vector_store`, `web_fetch` (SSRF-guard allowlist), the sandbox runner *type*, OTel) stay
+> file-only and need a restart. See [docs/AUTH.md](docs/AUTH.md) §admin config.
 
 ### Sign in
 
@@ -239,7 +239,12 @@ cd backend && uv run python -m evals.run_evals
   untrusted/multi-user execution use `sandbox.runner: container` (on-host, isolated) or
   `sandbox.runner: agentcore` (off-host AWS microVM) ([docs/SANDBOX.md](docs/SANDBOX.md)).
 - Mutating/execution tools default to the **`ask`** permission policy; "Agent mode"
-  auto-approves for a turn.
+  auto-approves for a turn. Sub-agents (`spawn_subagent`) inherit that same approval
+  state rather than granting themselves a bypass — if the turn isn't in Agent mode,
+  ask-tier tools a sub-agent tries to run are denied, not silently allowed.
+- **`web_fetch`** refuses private/loopback/link-local addresses (incl. the cloud metadata
+  IP) by default, so it can't be used to reach your internal network. Configurable via
+  `web_fetch` in `config.yml` (file-only) — see `config.yml.example`.
 - **Database:** SQLite by default; set `DATABASE_URL` to deploy against Postgres instead
   ([docs/DOCKER.md](docs/DOCKER.md)).
 - **Sensitive data (PHI):** audit logging, secrets management, and data governance are

--- a/backend/app/agent/events.py
+++ b/backend/app/agent/events.py
@@ -6,6 +6,7 @@ switches on ``type``:
   - thinking   : incremental reasoning text
   - token      : incremental final-answer text
   - tool_call  : a tool invocation began {id, name, arguments}
+  - tool_progress: incremental output from a still-running tool {id, name, content}
   - tool_result: a tool finished {id, name, content, is_error, artifacts}
   - artifact   : a file produced {name, path, ext, url}
   - usage      : token usage {input, output}
@@ -37,6 +38,11 @@ def token(text: str) -> str:
 
 def tool_call(call_id: str, name: str, arguments: dict) -> str:
     return sse("tool_call", id=call_id, name=name, arguments=arguments)
+
+
+def tool_progress(call_id: str, name: str, content: str) -> str:
+    """Incremental output from a tool that's still running (e.g. run_shell)."""
+    return sse("tool_progress", id=call_id, name=name, content=content)
 
 
 def tool_result(call_id: str, name: str, content: str, is_error: bool, artifacts: list) -> str:

--- a/backend/app/agent/harness.py
+++ b/backend/app/agent/harness.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 
 import json
 import logging
+import queue
+import threading
 from collections.abc import Iterator
+from dataclasses import replace
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -45,6 +49,7 @@ class AgentSession:
         ephemeral: bool = False,
         allowed_tools: set[str] | None = None,
         fallback_provider: LLMProvider | None = None,
+        cancel_event: threading.Event | None = None,
     ):
         self.db = db
         self.conversation = conversation
@@ -59,6 +64,11 @@ class AgentSession:
         self.ephemeral = ephemeral
         self.allowed_tools = allowed_tools
         self.final_text = ""
+        # Set by the caller (e.g. the chat router, watching for a client disconnect) so a
+        # user's "Stop" click can actually halt an in-flight turn — kill any running
+        # subprocess and stop the loop — instead of just closing the SSE connection while
+        # the turn keeps running server-side to completion.
+        self.cancel_event = cancel_event
         # Accumulated token usage across this turn (for observability + cost).
         self.turn_usage = {"input": 0, "output": 0, "total": 0}
         self.workspace = workspace_dir(conversation.id)
@@ -68,7 +78,12 @@ class AgentSession:
             db=db,
             runner=get_runner(),
             user_id=getattr(conversation, "user_id", None),
+            auto_approve=gate.auto_approve,
+            cancel_event=cancel_event,
         )
+
+    def _cancelled(self) -> bool:
+        return self.cancel_event is not None and self.cancel_event.is_set()
 
     # -- public entry points ------------------------------------------------
     def run(self, messages: list[dict]) -> Iterator[str]:
@@ -108,6 +123,9 @@ class AgentSession:
 
         used_fallback = False
         for _round in range(max_rounds):
+            if self._cancelled():
+                yield from self._finalize("", tool_steps, all_artifacts)
+                return
             round_text = ""
             pending_calls: list[ToolCall] = []
             stop_reason: str | None = None
@@ -115,6 +133,12 @@ class AgentSession:
                 streamed_any = False
                 try:
                     for delta in self.provider.stream(messages, tools, self.params):
+                        if self._cancelled():
+                            # Best-effort: stop consuming further streamed tokens/tool
+                            # calls as soon as we notice — the provider call itself may
+                            # not be interruptible mid-flight, but we stop paying
+                            # attention (and stop acting on it) immediately.
+                            break
                         if delta.type == "text":
                             streamed_any = True
                             round_text += delta.text or ""
@@ -197,8 +221,11 @@ class AgentSession:
         """Execute auto/approved calls; defer 'ask' calls. Returns True (via StopIteration
         value) if the turn paused awaiting approval."""
         ask_batch: list[ToolCall] = []
+        to_run: list[ToolCall] = []
 
         for call in calls:
+            if self._cancelled():
+                break
             if self.allowed_tools is not None and call.name not in self.allowed_tools:
                 decision = "not_enabled"
             elif decisions is not None and call.id in decisions:
@@ -216,21 +243,106 @@ class AgentSession:
                     content=f"Tool '{call.name}' is not enabled for this turn. Not executed.",
                     is_error=True,
                 )
+                yield from self._emit_result(call, result, tool_steps, all_artifacts, messages)
             elif decision == "deny":
                 result = ToolResult(content=f"Tool '{call.name}' was denied. Not executed.", is_error=True)
+                yield from self._emit_result(call, result, tool_steps, all_artifacts, messages)
             else:
-                yield events.status(f"Running {call.name}…")
-                result = self._execute_tool(call.name, call.arguments)
-                # Snapshot the workspace after a successful mutating tool, so the change
-                # is restorable (undo = restore the previous checkpoint).
+                to_run.append(call)
+
+        # spawn_subagent calls requested together in the same round are the model
+        # explicitly decomposing a task into independent chunks — run those in parallel.
+        # Everything else runs sequentially, as before (most tools mutate the same
+        # workspace files directly and aren't safe to run concurrently).
+        subagent_calls = [c for c in to_run if c.name == "spawn_subagent"]
+        other_calls = [c for c in to_run if c.name != "spawn_subagent"]
+
+        yield from self._run_sequential(other_calls, tool_steps, all_artifacts, messages)
+
+        if len(subagent_calls) >= 2:
+            yield events.status(f"Running {len(subagent_calls)} sub-agents…")
+            results = yield from self._run_calls_concurrently(subagent_calls)
+            for call, result in zip(subagent_calls, results, strict=True):
                 if not result.is_error:
                     self._maybe_checkpoint(call.name)
-
-            yield from self._emit_result(call, result, tool_steps, all_artifacts, messages)
+                yield from self._emit_result(call, result, tool_steps, all_artifacts, messages)
+        else:
+            yield from self._run_sequential(subagent_calls, tool_steps, all_artifacts, messages)
 
         if ask_batch:
             return (yield from self._pause(messages, ask_batch, tool_steps, all_artifacts))
         return False
+
+    def _run_sequential(
+        self,
+        calls: list[ToolCall],
+        tool_steps: list[dict],
+        all_artifacts: list[dict],
+        messages: list[dict],
+    ) -> Iterator[str]:
+        for call in calls:
+            if self._cancelled():
+                break
+            yield events.status(f"Running {call.name}…")
+            result = yield from self._execute_tool_streaming(call.id, call.name, call.arguments)
+            # Snapshot the workspace after a successful mutating tool, so the change is
+            # restorable (undo = restore the previous checkpoint).
+            if not result.is_error:
+                self._maybe_checkpoint(call.name)
+            yield from self._emit_result(call, result, tool_steps, all_artifacts, messages)
+
+    def _run_calls_concurrently(self, calls: list[ToolCall]) -> Iterator[str]:
+        """Run independent tool calls in parallel worker threads, interleaving their live
+        progress, and return their ``ToolResult``\\ s (same order as ``calls``) as the
+        generator's value (consumed via ``yield from``).
+
+        Only used for ``spawn_subagent`` batches: each call gets a *copy* of ``self.ctx``
+        with its own ``progress`` callback (concurrent tools can't share the single
+        ``self.ctx.progress`` the sequential path uses), but the copy still points at the
+        same shared ``db`` session — safe here only because ``spawn_subagent`` opens its
+        own isolated session and never touches ``ctx.db`` (see its module docstring). Do
+        not route a tool that *does* use ``ctx.db`` through this path without giving it
+        the same treatment.
+        """
+        progress_q: queue.Queue[tuple[str, str | None]] = queue.Queue()
+        holders: dict[str, dict[str, Any]] = {c.id: {} for c in calls}
+        names_by_id = {c.id: c.name for c in calls}
+
+        def worker(call: ToolCall) -> None:
+            tool = self.registry.get(call.name)
+            if tool is None:
+                holders[call.id]["result"] = ToolResult(content=f"Unknown tool: {call.name}", is_error=True)
+                progress_q.put((call.id, None))
+                return
+            call_ctx = replace(self.ctx, progress=lambda chunk, cid=call.id: progress_q.put((cid, chunk)))
+            try:
+                holders[call.id]["result"] = tool.run(call_ctx, **call.arguments)
+            except Exception as e:  # noqa: BLE001
+                logger.exception("Tool %s failed", call.name)
+                holders[call.id]["error"] = e
+            finally:
+                progress_q.put((call.id, None))
+
+        threads = [threading.Thread(target=worker, args=(c,), daemon=True) for c in calls]
+        for t in threads:
+            t.start()
+
+        remaining = {c.id for c in calls}
+        while remaining:
+            call_id, chunk = progress_q.get()
+            if chunk is None:
+                remaining.discard(call_id)
+                continue
+            yield events.tool_progress(call_id, names_by_id[call_id], chunk)
+        for t in threads:
+            t.join()
+
+        return [
+            ToolResult(content=f"Tool error: {holders[c.id]['error']}", is_error=True)
+            if "error" in holders[c.id]
+            else holders[c.id]["result"]
+            for c in calls
+        ]
 
     def _pause(
         self,
@@ -310,15 +422,46 @@ class AgentSession:
         except Exception:  # noqa: BLE001
             pass
 
-    def _execute_tool(self, name: str, arguments: dict) -> ToolResult:
+    def _execute_tool_streaming(self, call_id: str, name: str, arguments: dict) -> Iterator[str]:
+        """Run a tool in a worker thread, yielding ``tool_progress`` SSE frames for any
+        output it streams live (see ``ToolContext.progress``); returns the final
+        ``ToolResult`` as the generator's value (consumed via ``yield from``).
+
+        Tools run synchronously and the harness's own loop is a plain generator, so a
+        tool that wants to surface partial output *while it's still running* (a long
+        shell/code execution) needs somewhere else to run — a worker thread that pushes
+        chunks onto a queue, which this generator drains and re-yields as they arrive.
+        """
         tool = self.registry.get(name)
         if tool is None:
             return ToolResult(content=f"Unknown tool: {name}", is_error=True)
-        try:
-            return tool.run(self.ctx, **arguments)
-        except Exception as e:  # noqa: BLE001
-            logger.exception("Tool %s failed", name)
-            return ToolResult(content=f"Tool error: {e}", is_error=True)
+
+        progress_queue: queue.Queue[str | None] = queue.Queue()
+        holder: dict[str, Any] = {}
+
+        def worker() -> None:
+            try:
+                holder["result"] = tool.run(self.ctx, **arguments)
+            except Exception as e:  # noqa: BLE001
+                logger.exception("Tool %s failed", name)
+                holder["error"] = e
+            finally:
+                progress_queue.put(None)  # sentinel: no more progress coming
+
+        self.ctx.progress = progress_queue.put
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        while True:
+            chunk = progress_queue.get()
+            if chunk is None:
+                break
+            yield events.tool_progress(call_id, name, chunk)
+        t.join()
+        self.ctx.progress = None
+
+        if "error" in holder:
+            return ToolResult(content=f"Tool error: {holder['error']}", is_error=True)
+        return holder["result"]
 
     def _finalize(self, final_text: str, tool_steps: list[dict], all_artifacts: list[dict]) -> Iterator[str]:
         if self.ephemeral:

--- a/backend/app/agent/permissions.py
+++ b/backend/app/agent/permissions.py
@@ -42,10 +42,21 @@ def get_prefs(db: Session) -> dict[str, ToolPref]:
 class PermissionGate:
     """Decides whether a given tool call may run."""
 
-    def __init__(self, db: Session, registry: ToolRegistry, auto_approve: bool = False):
+    def __init__(
+        self,
+        db: Session,
+        registry: ToolRegistry,
+        auto_approve: bool = False,
+        interactive: bool = True,
+    ):
         self.prefs = get_prefs(db)
         self.registry = registry
         self.auto_approve = auto_approve
+        # Whether a human is actually present to answer an "ask" pause. Ephemeral
+        # sub-agents run unattended: nothing resumes a paused approval for them, so an
+        # "ask" tool there must resolve to "deny", not hang the turn on an unanswerable
+        # pause. Top-level turns (a real user in the loop) leave this True.
+        self.interactive = interactive
 
     def enabled_names(self) -> set[str]:
         names = set()
@@ -64,5 +75,7 @@ class PermissionGate:
         if policy == "deny":
             return "deny"
         if policy == "ask":
-            return "allow" if self.auto_approve else "ask"
+            if self.auto_approve:
+                return "allow"
+            return "ask" if self.interactive else "deny"
         return "allow"

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -8,13 +8,14 @@ To add a tool, subclass ``Tool`` and register it (see ``docs/ADDING_A_TOOL.md``)
 """
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from sqlalchemy.orm import Session
 
-from app.sandbox.runner import SandboxRunner
+from app.sandbox.runner import OutputCallback, SandboxRunner
 
 
 @dataclass
@@ -24,6 +25,19 @@ class ToolContext:
     db: Session
     runner: SandboxRunner
     user_id: str | None = None
+    #: whether the *current turn* is running with ask-tier tools auto-approved. Tools that
+    #: delegate to a nested agent (e.g. spawn_subagent) must respect this rather than
+    #: hardcoding their own approval policy — see PermissionGate(interactive=...).
+    auto_approve: bool = False
+    #: set by the harness for the duration of a single tool call; a long-running tool
+    #: (run_shell, execute_python/node) forwards it to the sandbox runner so partial
+    #: output streams to the UI as it's produced, instead of only appearing once the
+    #: whole command finishes.
+    progress: OutputCallback | None = None
+    #: set once per turn; a long-running tool forwards it to the sandbox runner so a
+    #: user's "Stop" click (or the turn otherwise being cancelled) actually kills an
+    #: in-flight subprocess instead of leaving it running server-side to completion.
+    cancel_event: threading.Event | None = None
 
 
 @dataclass

--- a/backend/app/agent/tools/code.py
+++ b/backend/app/agent/tools/code.py
@@ -18,7 +18,8 @@ def _format(res, label: str) -> ToolResult:
         parts.append(f"[stderr]\n{res.stderr}")
     if not parts:
         parts.append("(no output)")
-    parts.append(f"[{label} exit {res.exit_code}{' — TIMEOUT' if res.timed_out else ''}, {res.duration_s}s]")
+    status = " — TIMEOUT" if res.timed_out else (" — CANCELLED" if res.cancelled else "")
+    parts.append(f"[{label} exit {res.exit_code}{status}, {res.duration_s}s]")
     if res.artifacts:
         parts.append("[artifacts] " + ", ".join(a["name"] for a in res.artifacts))
     return ToolResult(content="\n".join(parts), artifacts=res.artifacts, is_error=res.exit_code != 0)
@@ -43,7 +44,9 @@ class ExecutePython(Tool):
     }
 
     def run(self, ctx: ToolContext, code: str = "", timeout: int = 60, **_: Any) -> ToolResult:
-        res = ctx.runner.run_code(code, "python", ctx.workspace, timeout=timeout)
+        res = ctx.runner.run_code(
+            code, "python", ctx.workspace, timeout=timeout, on_output=ctx.progress, cancel_event=ctx.cancel_event
+        )
         return _format(res, "python")
 
 
@@ -62,5 +65,7 @@ class ExecuteNode(Tool):
     }
 
     def run(self, ctx: ToolContext, code: str = "", timeout: int = 60, **_: Any) -> ToolResult:
-        res = ctx.runner.run_code(code, "node", ctx.workspace, timeout=timeout)
+        res = ctx.runner.run_code(
+            code, "node", ctx.workspace, timeout=timeout, on_output=ctx.progress, cancel_event=ctx.cancel_event
+        )
         return _format(res, "node")

--- a/backend/app/agent/tools/fs.py
+++ b/backend/app/agent/tools/fs.py
@@ -6,9 +6,18 @@ import re
 from typing import Any
 
 from app.agent.tools.base import Tool, ToolContext, ToolResult
+from app.sandbox.runner import IGNORE_DIRS
 from app.workspace.manager import resolve_in_workspace
 
 MAX_READ_CHARS = 30_000
+DEFAULT_READ_LIMIT_LINES = 2000
+MAX_SEARCH_RESULTS = 200
+
+
+def _skip_dir(rel_parts: tuple[str, ...]) -> bool:
+    """True if a path (relative to the workspace root) is inside a vendor/build/VCS dir
+    that shouldn't clutter search results (node_modules, .venv, .git, ...)."""
+    return any(part in IGNORE_DIRS for part in rel_parts)
 
 
 def _rel(ctx: ToolContext, path) -> str:
@@ -29,25 +38,61 @@ def _artifact(ctx: ToolContext, p) -> list[dict]:
 
 class ReadFile(Tool):
     name = "read_file"
-    description = "Read a UTF-8 text file from the workspace. Returns its contents."
+    description = (
+        "Read a UTF-8 text file from the workspace. Returns its contents. For files "
+        f"longer than {DEFAULT_READ_LIMIT_LINES} lines, only the requested window is "
+        "returned — pass offset/limit to page through the rest."
+    )
     category = "filesystem"
     default_permission = "auto"
     parameters: dict[str, Any] = {
         "type": "object",
-        "properties": {"path": {"type": "string", "description": "Path relative to the workspace root"}},
+        "properties": {
+            "path": {"type": "string", "description": "Path relative to the workspace root"},
+            "offset": {
+                "type": "integer",
+                "description": "1-indexed line number to start reading from",
+                "default": 1,
+            },
+            "limit": {
+                "type": "integer",
+                "description": f"Max lines to return (default {DEFAULT_READ_LIMIT_LINES})",
+                "default": DEFAULT_READ_LIMIT_LINES,
+            },
+        },
         "required": ["path"],
     }
 
-    def run(self, ctx: ToolContext, path: str = "", **_: Any) -> ToolResult:
+    def run(
+        self,
+        ctx: ToolContext,
+        path: str = "",
+        offset: int = 1,
+        limit: int = DEFAULT_READ_LIMIT_LINES,
+        **_: Any,
+    ) -> ToolResult:
         try:
             p = resolve_in_workspace(ctx.conversation_id, path)
         except ValueError as e:
             return ToolResult(content=str(e), is_error=True)
         if not p.is_file():
             return ToolResult(content=f"No such file: {path}", is_error=True)
-        text = p.read_text(encoding="utf-8", errors="replace")
+
+        lines = p.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+        total = len(lines)
+        start = max(int(offset or 1) - 1, 0)
+        window = lines[start : start + max(int(limit or DEFAULT_READ_LIMIT_LINES), 1)]
+        end = start + len(window)
+        text = "".join(window)
+
+        notes = []
         if len(text) > MAX_READ_CHARS:
-            text = text[:MAX_READ_CHARS] + "\n... [truncated]"
+            text = text[:MAX_READ_CHARS]
+            notes.append(f"truncated at {MAX_READ_CHARS} chars")
+        if start > 0 or end < total:
+            notes.append(f"showing lines {start + 1}-{end} of {total}; use offset/limit to see more")
+        if notes:
+            text += f"\n... [{'; '.join(notes)}]"
         return ToolResult(content=text)
 
 
@@ -161,9 +206,20 @@ class GlobSearch(Tool):
 
     def run(self, ctx: ToolContext, pattern: str = "*", **_: Any) -> ToolResult:
         root = resolve_in_workspace(ctx.conversation_id, ".")
-        matches = [str(p.relative_to(root)) for p in root.rglob("*") if fnmatch.fnmatch(str(p.relative_to(root)), pattern)]
+        matches = []
+        for p in root.rglob("*"):
+            rel = p.relative_to(root)
+            if _skip_dir(rel.parts) or not fnmatch.fnmatch(str(rel), pattern):
+                continue
+            matches.append(str(rel))
         matches.sort()
-        return ToolResult(content="\n".join(matches[:200]) if matches else "(no matches)")
+        if not matches:
+            return ToolResult(content="(no matches)")
+        shown = matches[:MAX_SEARCH_RESULTS]
+        content = "\n".join(shown)
+        if len(matches) > MAX_SEARCH_RESULTS:
+            content += f"\n... [{len(matches) - MAX_SEARCH_RESULTS} more matches not shown; narrow the pattern]"
+        return ToolResult(content=content)
 
 
 class GrepSearch(Tool):
@@ -186,17 +242,25 @@ class GrepSearch(Tool):
             return ToolResult(content=f"Bad regex: {e}", is_error=True)
         root = resolve_in_workspace(ctx.conversation_id, ".")
         out: list[str] = []
+        truncated = False
         for p in root.rglob("*"):
-            if not p.is_file() or not fnmatch.fnmatch(p.name, glob):
+            rel = p.relative_to(root)
+            if not p.is_file() or _skip_dir(rel.parts) or not fnmatch.fnmatch(p.name, glob):
                 continue
             try:
                 for i, line in enumerate(p.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
                     if rx.search(line):
-                        out.append(f"{p.relative_to(root)}:{i}: {line.strip()[:200]}")
-                        if len(out) >= 200:
+                        out.append(f"{rel}:{i}: {line.strip()[:200]}")
+                        if len(out) >= MAX_SEARCH_RESULTS:
+                            truncated = True
                             break
             except OSError:
                 continue
-            if len(out) >= 200:
+            if truncated:
                 break
-        return ToolResult(content="\n".join(out) if out else "(no matches)")
+        if not out:
+            return ToolResult(content="(no matches)")
+        content = "\n".join(out)
+        if truncated:
+            content += f"\n... [stopped at {MAX_SEARCH_RESULTS} matches; narrow the pattern or glob to see more]"
+        return ToolResult(content=content)

--- a/backend/app/agent/tools/shell.py
+++ b/backend/app/agent/tools/shell.py
@@ -32,13 +32,16 @@ class RunShell(Tool):
             argv = ["cmd", "/c", command]
         else:
             argv = ["/bin/sh", "-c", command]
-        res = ctx.runner.run_command(argv, ctx.workspace, timeout=timeout)
+        res = ctx.runner.run_command(
+            argv, ctx.workspace, timeout=timeout, on_output=ctx.progress, cancel_event=ctx.cancel_event
+        )
         parts = []
         if res.stdout:
             parts.append(res.stdout)
         if res.stderr:
             parts.append(f"[stderr]\n{res.stderr}")
-        parts.append(f"[exit {res.exit_code}{' — TIMEOUT' if res.timed_out else ''}]")
+        status = " — TIMEOUT" if res.timed_out else (" — CANCELLED" if res.cancelled else "")
+        parts.append(f"[exit {res.exit_code}{status}]")
         return ToolResult(
             content="\n".join(parts),
             artifacts=res.artifacts,

--- a/backend/app/agent/tools/subagent.py
+++ b/backend/app/agent/tools/subagent.py
@@ -6,6 +6,12 @@ runs it to completion, and returns its final answer as the tool result. This let
 agent decompose big tasks (e.g. "research X", "implement Y") and keep its own context lean.
 
 Recursion is prevented by excluding ``spawn_subagent`` from the child's toolset.
+
+The harness can run *multiple* ``spawn_subagent`` calls from the same round concurrently
+(see ``AgentSession._run_calls_concurrently``), so this tool opens its **own** DB session
+rather than reusing ``ctx.db`` — a SQLAlchemy ``Session`` isn't safe to use from more than
+one thread at a time, and ``ctx.db`` is the same shared session across every tool call in
+the turn.
 """
 from __future__ import annotations
 
@@ -52,62 +58,73 @@ class SpawnSubagent(Tool):
         from app.agent.harness import AgentSession
         from app.agent.permissions import PermissionGate
         from app.agent.registry import REGISTRY
+        from app.database import SessionLocal
         from app.models import Conversation
         from app.providers.registry import build_provider
         from app.runtime_settings import generation_params, get_settings
 
-        conversation = ctx.db.get(Conversation, ctx.conversation_id)
-        if conversation is None:
-            return ToolResult(content="Conversation not found.", is_error=True)
-
-        settings = get_settings(ctx.db)
-        profile = settings["active_profile"]
-        model = settings.get("model")
+        # Own session — see the module docstring on why this can't reuse ctx.db.
+        db = SessionLocal()
         try:
-            provider = build_provider(profile, model)
-        except Exception as e:  # noqa: BLE001
-            return ToolResult(content=f"Sub-agent provider error: {e}", is_error=True)
+            conversation = db.get(Conversation, ctx.conversation_id)
+            if conversation is None:
+                return ToolResult(content="Conversation not found.", is_error=True)
 
-        params = {**generation_params(settings), "max_tool_rounds": 8}
-        gate = PermissionGate(ctx.db, REGISTRY, auto_approve=True)  # scoped + auto within the sub-task
-        allowed = SUBAGENT_TOOLS & set(REGISTRY.names())
-
-        session = AgentSession(
-            ctx.db, conversation, provider, REGISTRY, gate, params, profile, model,
-            ephemeral=True, allowed_tools=allowed,
-        )
-        messages = [
-            {"role": "system", "content": SUBAGENT_SYSTEM},
-            {"role": "user", "content": task},
-        ]
-        # Drive the ephemeral session, building the answer from its event stream so we
-        # robustly capture output (and surface errors / the last tool result).
-        import json as _json
-
-        answer = ""
-        err: str | None = None
-        last_tool: str | None = None
-        for frame in session.run(messages):
-            line = frame.strip()
-            if not line.startswith("data: "):
-                continue
+            settings = get_settings(db)
+            profile = settings["active_profile"]
+            model = settings.get("model")
             try:
-                ev = _json.loads(line[6:])
-            except ValueError:
-                continue
-            if ev["type"] == "token":
-                answer += ev.get("content", "")
-            elif ev["type"] == "error":
-                err = ev.get("content")
-            elif ev["type"] == "tool_result":
-                last_tool = ev.get("content")
+                provider = build_provider(profile, model)
+            except Exception as e:  # noqa: BLE001
+                return ToolResult(content=f"Sub-agent provider error: {e}", is_error=True)
 
-        content = answer.strip() or session.final_text.strip()
-        if not content:
-            if err:
-                content = f"Sub-agent error: {err}"
-            elif last_tool:
-                content = f"Sub-agent ran tools. Last result:\n{last_tool}"
-            else:
-                content = "(sub-agent produced no output)"
-        return ToolResult(content=content)
+            params = {**generation_params(settings), "max_tool_rounds": 8}
+            # Inherit the parent turn's real approval state — a sub-agent must not grant
+            # itself permissions the user didn't give the parent turn. If the turn isn't
+            # in auto-approve mode, ask-tier tools (run_shell, write_file, ...) resolve to
+            # "deny" here rather than "ask": a sub-agent runs unattended, so there's no
+            # one to answer an approval pause. See PermissionGate(interactive=False).
+            gate = PermissionGate(db, REGISTRY, auto_approve=ctx.auto_approve, interactive=False)
+            allowed = SUBAGENT_TOOLS & set(REGISTRY.names())
+
+            session = AgentSession(
+                db, conversation, provider, REGISTRY, gate, params, profile, model,
+                ephemeral=True, allowed_tools=allowed, cancel_event=ctx.cancel_event,
+            )
+            messages = [
+                {"role": "system", "content": SUBAGENT_SYSTEM},
+                {"role": "user", "content": task},
+            ]
+            # Drive the ephemeral session, building the answer from its event stream so
+            # we robustly capture output (and surface errors / the last tool result).
+            import json as _json
+
+            answer = ""
+            err: str | None = None
+            last_tool: str | None = None
+            for frame in session.run(messages):
+                line = frame.strip()
+                if not line.startswith("data: "):
+                    continue
+                try:
+                    ev = _json.loads(line[6:])
+                except ValueError:
+                    continue
+                if ev["type"] == "token":
+                    answer += ev.get("content", "")
+                elif ev["type"] == "error":
+                    err = ev.get("content")
+                elif ev["type"] == "tool_result":
+                    last_tool = ev.get("content")
+
+            content = answer.strip() or session.final_text.strip()
+            if not content:
+                if err:
+                    content = f"Sub-agent error: {err}"
+                elif last_tool:
+                    content = f"Sub-agent ran tools. Last result:\n{last_tool}"
+                else:
+                    content = "(sub-agent produced no output)"
+            return ToolResult(content=content)
+        finally:
+            db.close()

--- a/backend/app/agent/tools/web.py
+++ b/backend/app/agent/tools/web.py
@@ -1,18 +1,71 @@
 """Web fetch/search tools."""
 from __future__ import annotations
 
+import ipaddress
 import json
 import re
+import socket
 from typing import Any
+from urllib.parse import urlparse
 
 from app.agent.tools.base import Tool, ToolContext, ToolResult
-from app.config import get_web_search_config
+from app.config import get_web_fetch_config, get_web_search_config
 
 MAX_CHARS = 20_000
 MAX_SEARCH_RESULTS = 10
 DEFAULT_SEARCH_RESULTS = 5
 MAX_SEARCH_TITLE_CHARS = 200
 MAX_SEARCH_SNIPPET_CHARS = 500
+MAX_REDIRECTS = 5
+
+
+def _host_allowlisted(host: str, allowlist: list[str]) -> bool:
+    for raw in allowlist:
+        entry = str(raw or "").strip()
+        if not entry:
+            continue
+        if entry.lower() == host.lower():
+            return True
+        try:
+            if ipaddress.ip_address(host) in ipaddress.ip_network(entry, strict=False):
+                return True
+        except ValueError:
+            continue  # entry isn't an IP/CIDR and didn't match as a hostname
+    return False
+
+
+def _is_blocked_ip(ip_str: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # unparseable — fail closed
+    return (
+        ip.is_private or ip.is_loopback or ip.is_link_local
+        or ip.is_reserved or ip.is_multicast or ip.is_unspecified
+    )
+
+
+def _ssrf_guard(url: str) -> str | None:
+    """Return an error message if ``url`` targets a disallowed private/internal address,
+    else None. Re-run on every redirect hop, not just the original URL — otherwise a
+    public host that 302s to an internal address would slip past a one-time check."""
+    cfg = get_web_fetch_config()
+    if cfg.get("allow_private_networks"):
+        return None
+    host = urlparse(url).hostname
+    if not host:
+        return "URL has no host"
+    if _host_allowlisted(host, cfg.get("allowlist_hosts") or []):
+        return None
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError as e:
+        return f"Could not resolve host {host!r}: {e}"
+    for info in infos:
+        ip_str = info[4][0]
+        if _is_blocked_ip(ip_str):
+            return f"Blocked: {host!r} resolves to a private/internal address ({ip_str})"
+    return None
 
 
 def _html_to_text(html: str) -> str:
@@ -69,13 +122,30 @@ class WebFetch(Tool):
         try:
             import httpx
 
-            resp = httpx.get(url, follow_redirects=True, timeout=20.0, headers={"User-Agent": "Phlox/0.1"})
+            current = url
+            # Follow redirects manually (rather than httpx's follow_redirects=True) so
+            # every hop is re-checked by the SSRF guard — a public host that redirects to
+            # an internal address must not slip through on the strength of the first check.
+            for _hop in range(MAX_REDIRECTS + 1):
+                blocked = _ssrf_guard(current)
+                if blocked:
+                    return ToolResult(content=blocked, is_error=True)
+                resp = httpx.get(
+                    current, follow_redirects=False, timeout=20.0, headers={"User-Agent": "Phlox/0.1"}
+                )
+                if resp.is_redirect and resp.headers.get("location"):
+                    current = str(httpx.URL(current).join(resp.headers["location"]))
+                    continue
+                break
+            else:
+                return ToolResult(content=f"Too many redirects fetching {url}", is_error=True)
+
             ctype = resp.headers.get("content-type", "")
             body = resp.text
             text = _html_to_text(body) if "html" in ctype else body
             if len(text) > MAX_CHARS:
                 text = text[:MAX_CHARS] + "\n... [truncated]"
-            return ToolResult(content=f"HTTP {resp.status_code} {url}\n\n{text}")
+            return ToolResult(content=f"HTTP {resp.status_code} {current}\n\n{text}")
         except Exception as e:  # noqa: BLE001
             return ToolResult(content=f"Fetch failed: {e}", is_error=True)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -144,6 +144,22 @@ def get_web_search_config() -> dict[str, Any]:
     return cfg
 
 
+def get_web_fetch_config() -> dict[str, Any]:
+    """``web_fetch`` SSRF guard settings.
+
+    By default, ``web_fetch`` refuses to reach private/loopback/link-local addresses
+    (including the cloud metadata IP, 169.254.169.254) so an uploaded prompt can't use the
+    agent as a pivot into your internal network. Set ``web_fetch.allow_private_networks:
+    true`` to disable the guard entirely, or list specific hostnames/IPs/CIDRs under
+    ``web_fetch.allowlist_hosts`` to punch through the guard for just those targets (e.g.
+    an internal API you want the agent to be able to call).
+    """
+    cfg = dict(load_config().get("web_fetch", {}) or {})
+    cfg.setdefault("allow_private_networks", False)
+    cfg.setdefault("allowlist_hosts", [])
+    return cfg
+
+
 def get_sandbox_config() -> dict[str, Any]:
     """Code/shell execution sandbox config. ``runner`` is ``local``, ``container``, or ``agentcore``.
 

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -3,13 +3,14 @@ POST /api/chat/approve — resume a paused turn with the user's tool-approval de
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
-
-from fastapi import HTTPException
+from starlette.background import BackgroundTask
 
 from app.agent import events
 from app.agent.context import compact_history
@@ -250,6 +251,27 @@ def _referenced_document_context(
     return "\n".join(blocks)
 
 
+async def _watch_disconnect(request: Request, cancel_event: threading.Event) -> None:
+    """Set ``cancel_event`` as soon as the client disconnects.
+
+    Starlette's ``StreamingResponse`` already stops *reading* the response body on
+    disconnect, but that alone doesn't stop the harness's generator — it keeps running
+    (and can keep a subprocess alive) on its worker thread until it next reaches a yield
+    point. This watcher runs concurrently on the event loop and gives the harness a
+    signal it can actually check, so "Stop" kills in-flight work instead of just walking
+    away from it. The loop also exits as soon as the turn finishes normally — ``stream()``
+    sets ``cancel_event`` itself in a ``finally``, so this doesn't poll forever.
+    """
+    try:
+        while not cancel_event.is_set():
+            if await request.is_disconnected():
+                cancel_event.set()
+                return
+            await asyncio.sleep(0.5)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _build_fallback(active_profile: str):
     """Build the configured fallback provider (if any and distinct from the active one)."""
     from app.config import get_resilience_config
@@ -265,7 +287,9 @@ def _build_fallback(active_profile: str):
 
 
 @router.post("/chat")
-def chat(req: ChatRequest, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+async def chat(
+    req: ChatRequest, request: Request, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
     settings = get_settings(db, user.id)
     profile = req.profile or settings["active_profile"]
     model = req.model or settings.get("model")
@@ -345,80 +369,101 @@ def chat(req: ChatRequest, db: Session = Depends(get_db), user: User = Depends(g
         ),
     }
 
+    cancel_event = threading.Event()
+
     def stream():
-        yield events.sse("conversation", id=conversation.id, title=conversation.title)
         try:
-            provider = build_provider(profile, model)
-        except Exception as e:  # noqa: BLE001
-            logger.exception("Provider build failed")
-            yield events.error(f"Provider error: {e}")
-            yield events.done("")
-            return
+            yield events.sse("conversation", id=conversation.id, title=conversation.title)
+            try:
+                provider = build_provider(profile, model)
+            except Exception as e:  # noqa: BLE001
+                logger.exception("Provider build failed")
+                yield events.error(f"Provider error: {e}")
+                yield events.done("")
+                return
 
-        # Build an optional fallback provider (used if the primary errors mid-stream).
-        fallback = _build_fallback(profile)
+            # Build an optional fallback provider (used if the primary errors mid-stream).
+            fallback = _build_fallback(profile)
 
-        # Compact long histories to stay within the per-user context budget.
-        compacted, did = compact_history(provider, history, int(settings["max_context_tokens"]))
-        if did:
-            yield events.status("Summarizing earlier context…")
+            # Compact long histories to stay within the per-user context budget.
+            compacted, did = compact_history(provider, history, int(settings["max_context_tokens"]))
+            if did:
+                yield events.status("Summarizing earlier context…")
 
-        gate = PermissionGate(db, REGISTRY, auto_approve=req.auto_approve)
-        enabled_tools = gate.enabled_names()
-        if not req.web_search:
-            enabled_tools.discard("web_search")
-        if not (req.document_search or referenced_docs):
-            enabled_tools.discard("search_documents")
-        session = AgentSession(
-            db, conversation, provider, REGISTRY, gate, params, profile, model,
-            allowed_tools=enabled_tools,
-            fallback_provider=fallback,
-        )
-        yield from session.run(compacted)
+            gate = PermissionGate(db, REGISTRY, auto_approve=req.auto_approve)
+            enabled_tools = gate.enabled_names()
+            if not req.web_search:
+                enabled_tools.discard("web_search")
+            if not (req.document_search or referenced_docs):
+                enabled_tools.discard("search_documents")
+            session = AgentSession(
+                db, conversation, provider, REGISTRY, gate, params, profile, model,
+                allowed_tools=enabled_tools,
+                fallback_provider=fallback,
+                cancel_event=cancel_event,
+            )
+            yield from session.run(compacted)
+        finally:
+            # Ends the disconnect watcher promptly on normal completion too (it would
+            # otherwise keep polling until its own timeout).
+            cancel_event.set()
 
-    return StreamingResponse(stream(), media_type="text/event-stream")
+    watcher = asyncio.create_task(_watch_disconnect(request, cancel_event))
+    return StreamingResponse(
+        stream(), media_type="text/event-stream", background=BackgroundTask(watcher.cancel)
+    )
 
 
 @router.post("/chat/approve")
-def approve(req: ApproveRequest, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+async def approve(
+    req: ApproveRequest, request: Request, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
     """Resume a paused turn. ``decisions`` maps tool-call id -> 'allow' | 'deny'."""
     pending = db.get(PendingApproval, req.pending_id)
+    cancel_event = threading.Event()
 
     def stream():
-        if pending is None:
-            yield events.error("This approval request is no longer valid.")
-            yield events.done("")
-            return
-
-        state = pending.state
-        conversation = db.get(Conversation, pending.conversation_id)
-        if conversation is None:
-            yield events.error("Conversation not found.")
-            yield events.done("")
-            return
-        if conversation.user_id != user.id:
-            yield events.error("Not authorized.")
-            yield events.done("")
-            return
-
-        yield events.sse("conversation", id=conversation.id, title=conversation.title)
         try:
-            provider = build_provider(state["profile"], state.get("model"))
-        except Exception as e:  # noqa: BLE001
-            yield events.error(f"Provider error: {e}")
-            yield events.done("")
-            return
+            if pending is None:
+                yield events.error("This approval request is no longer valid.")
+                yield events.done("")
+                return
 
-        gate = PermissionGate(db, REGISTRY, auto_approve=False)
-        allowed_tools = state.get("allowed_tools")
-        session = AgentSession(
-            db, conversation, provider, REGISTRY, gate,
-            state.get("params", {}), state["profile"], state.get("model"),
-            allowed_tools=set(allowed_tools) if allowed_tools is not None else None,
-        )
-        # Consume the pending row before resuming (it's superseded once we continue).
-        db.delete(pending)
-        db.commit()
-        yield from session.resume(state, req.decisions)
+            state = pending.state
+            conversation = db.get(Conversation, pending.conversation_id)
+            if conversation is None:
+                yield events.error("Conversation not found.")
+                yield events.done("")
+                return
+            if conversation.user_id != user.id:
+                yield events.error("Not authorized.")
+                yield events.done("")
+                return
 
-    return StreamingResponse(stream(), media_type="text/event-stream")
+            yield events.sse("conversation", id=conversation.id, title=conversation.title)
+            try:
+                provider = build_provider(state["profile"], state.get("model"))
+            except Exception as e:  # noqa: BLE001
+                yield events.error(f"Provider error: {e}")
+                yield events.done("")
+                return
+
+            gate = PermissionGate(db, REGISTRY, auto_approve=False)
+            allowed_tools = state.get("allowed_tools")
+            session = AgentSession(
+                db, conversation, provider, REGISTRY, gate,
+                state.get("params", {}), state["profile"], state.get("model"),
+                allowed_tools=set(allowed_tools) if allowed_tools is not None else None,
+                cancel_event=cancel_event,
+            )
+            # Consume the pending row before resuming (it's superseded once we continue).
+            db.delete(pending)
+            db.commit()
+            yield from session.resume(state, req.decisions)
+        finally:
+            cancel_event.set()
+
+    watcher = asyncio.create_task(_watch_disconnect(request, cancel_event))
+    return StreamingResponse(
+        stream(), media_type="text/event-stream", background=BackgroundTask(watcher.cancel)
+    )

--- a/backend/app/sandbox/runner.py
+++ b/backend/app/sandbox/runner.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import threading
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -25,12 +27,46 @@ from pathlib import Path
 MAX_OUTPUT_CHARS = 30_000
 DEFAULT_TIMEOUT = 60
 
+# How often the local runner's wait-loop wakes to check for a timeout or a cancellation
+# request. Small enough that "Stop" / a timeout feels responsive without busy-waiting.
+_POLL_INTERVAL_S = 0.2
+
+#: called with each new chunk of stdout/stderr as it's produced, for live progress.
+OutputCallback = Callable[[str], None]
+
+
+def _tree_kill_popen_kwargs() -> dict:
+    """Extra ``Popen`` kwargs so the child starts its own process group/session — required
+    so a timeout/cancel can kill the whole tree, not just the immediate child.
+
+    Without this, killing e.g. a ``/bin/sh -c '... some-build-tool ...'`` process only
+    kills the shell; any process it forked (the actual build/test tool) is orphaned and
+    keeps running to completion regardless of the timeout, silently burning CPU after we've
+    already reported the run as timed out/cancelled.
+    """
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _kill_process_tree(proc: subprocess.Popen) -> None:
+    """Kill ``proc`` and everything it spawned (see ``_tree_kill_popen_kwargs``)."""
+    try:
+        if sys.platform == "win32":
+            subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], capture_output=True, timeout=5)
+        else:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+    finally:
+        proc.kill()  # belt-and-suspenders: ensure the immediate child is dead either way
+
 # Inline image preview extensions (rendered in the chat); all other produced files are
 # still captured as downloadable artifacts and shown in the workspace files panel.
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
 
 # Directories/files to ignore when detecting produced artifacts (internal/noise).
-_IGNORE_DIRS = {".git", ".hutchchat", "__pycache__", "node_modules", ".venv", ".cache"}
+IGNORE_DIRS = {".git", ".hutchchat", "__pycache__", "node_modules", ".venv", ".cache"}
 _IGNORE_EXTS = {".pyc", ".pyo"}
 MAX_ARTIFACTS = 30
 
@@ -44,6 +80,8 @@ class ExecResult:
     duration_s: float = 0.0
     # New/changed files detected after the run, relative to the workspace.
     artifacts: list[dict] = field(default_factory=list)
+    # True if a cancellation request (not a timeout) killed the process early.
+    cancelled: bool = False
 
 
 def _truncate(s: str) -> str:
@@ -54,10 +92,25 @@ def _truncate(s: str) -> str:
 
 class SandboxRunner(ABC):
     @abstractmethod
-    def run_command(self, argv: list[str], workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult: ...
+    def run_command(
+        self,
+        argv: list[str],
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult: ...
 
     @abstractmethod
-    def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult: ...
+    def run_code(
+        self,
+        code: str,
+        language: str,
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult: ...
 
     def close_session(self, workdir: Path) -> None:
         """Tear down any per-conversation remote session for this workspace.
@@ -90,7 +143,7 @@ def collect_artifacts(workdir: Path, before: dict[str, float]) -> list[dict]:
         if not p.is_file():
             continue
         rel = p.relative_to(workdir)
-        if any(part in _IGNORE_DIRS for part in rel.parts):
+        if any(part in IGNORE_DIRS for part in rel.parts):
             continue
         if p.suffix.lower() in _IGNORE_EXTS:
             continue
@@ -110,6 +163,106 @@ def collect_artifacts(workdir: Path, before: dict[str, float]) -> list[dict]:
     return arts
 
 
+@dataclass
+class _RawResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool = False
+    cancelled: bool = False
+
+
+def _run_popen(
+    argv: list[str],
+    cwd: Path,
+    timeout: int,
+    on_output: OutputCallback | None = None,
+    cancel_event: threading.Event | None = None,
+    env: dict | None = None,
+    stdin: str | None = None,
+) -> _RawResult:
+    """Run ``argv``, streaming stdout/stderr live via ``on_output`` as it's produced, and
+    killing the process early on a timeout or a cancellation request.
+
+    ``subprocess.run`` can't do either: it blocks until exit and only hands back output
+    once the process is already gone, and a "Stop" click has nothing to kill until then.
+    Popen + a short poll loop fixes both — shared by the local and container runners
+    since both just wrap a child process.
+    """
+    stdout_chunks: list[str] = []
+    stderr_chunks: list[str] = []
+
+    def _reader(stream, sink: list[str], label: str) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                sink.append(line)
+                if on_output:
+                    try:
+                        on_output(f"[{label}] {line}" if label else line)
+                    except Exception:  # noqa: BLE001
+                        pass
+        finally:
+            stream.close()
+
+    proc = subprocess.Popen(  # noqa: S603 - argv is caller-constructed, not shell-interpreted here
+        argv,
+        cwd=str(cwd),
+        stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        errors="replace",
+        bufsize=1,
+        env=env,
+        **_tree_kill_popen_kwargs(),
+    )
+    readers = [
+        threading.Thread(target=_reader, args=(proc.stdout, stdout_chunks, ""), daemon=True),
+        threading.Thread(target=_reader, args=(proc.stderr, stderr_chunks, "stderr"), daemon=True),
+    ]
+    for t in readers:
+        t.start()
+    if stdin is not None:
+        try:
+            proc.stdin.write(stdin)
+        finally:
+            proc.stdin.close()
+
+    start = time.monotonic()
+    timed_out = False
+    cancelled = False
+    while True:
+        try:
+            proc.wait(timeout=_POLL_INTERVAL_S)
+            break
+        except subprocess.TimeoutExpired:
+            if time.monotonic() - start > timeout:
+                timed_out = True
+                _kill_process_tree(proc)
+                proc.wait()
+                break
+            if cancel_event is not None and cancel_event.is_set():
+                cancelled = True
+                _kill_process_tree(proc)
+                proc.wait()
+                break
+    for t in readers:
+        t.join(timeout=5)
+
+    stderr = "".join(stderr_chunks)
+    if timed_out:
+        stderr += f"\n[timed out after {timeout}s]"
+    elif cancelled:
+        stderr += "\n[cancelled]"
+    return _RawResult(
+        stdout="".join(stdout_chunks),
+        stderr=stderr,
+        exit_code=proc.returncode if proc.returncode is not None else -1,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    )
+
+
 class LocalSubprocessRunner(SandboxRunner):
     def _snapshot(self, workdir: Path) -> dict[str, float]:
         return snapshot_dir(workdir)
@@ -117,54 +270,63 @@ class LocalSubprocessRunner(SandboxRunner):
     def _collect_artifacts(self, workdir: Path, before: dict[str, float]) -> list[dict]:
         return collect_artifacts(workdir, before)
 
-    def _exec(self, argv: list[str], workdir: Path, timeout: int, stdin: str | None = None) -> ExecResult:
+    def _exec(
+        self,
+        argv: list[str],
+        workdir: Path,
+        timeout: int,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+        stdin: str | None = None,
+    ) -> ExecResult:
         workdir.mkdir(parents=True, exist_ok=True)
         before = self._snapshot(workdir)
         env = dict(os.environ)
         env["PYTHONUNBUFFERED"] = "1"
         start = time.monotonic()
-        timed_out = False
         try:
-            proc = subprocess.run(
-                argv,
-                cwd=str(workdir),
-                input=stdin,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=env,
+            raw = _run_popen(
+                argv, workdir, timeout, on_output=on_output, cancel_event=cancel_event, env=env, stdin=stdin
             )
-            stdout, stderr, code = proc.stdout, proc.stderr, proc.returncode
-        except subprocess.TimeoutExpired as e:
-            timed_out = True
-            stdout = e.stdout or ""
-            stderr = (e.stderr or "") + f"\n[timed out after {timeout}s]"
-            code = -1
-            if isinstance(stdout, bytes):
-                stdout = stdout.decode("utf-8", "replace")
-            if isinstance(stderr, bytes):
-                stderr = stderr.decode("utf-8", "replace")
         except FileNotFoundError as e:
             return ExecResult(stdout="", stderr=f"Executable not found: {e}", exit_code=127)
 
         return ExecResult(
-            stdout=_truncate(stdout),
-            stderr=_truncate(stderr),
-            exit_code=code,
-            timed_out=timed_out,
+            stdout=_truncate(raw.stdout),
+            stderr=_truncate(raw.stderr),
+            exit_code=raw.exit_code,
+            timed_out=raw.timed_out,
+            cancelled=raw.cancelled,
             duration_s=round(time.monotonic() - start, 3),
             artifacts=self._collect_artifacts(workdir, before),
         )
 
-    def run_command(self, argv: list[str], workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
-        return self._exec(argv, workdir, timeout)
+    def run_command(
+        self,
+        argv: list[str],
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
+        return self._exec(argv, workdir, timeout, on_output=on_output, cancel_event=cancel_event)
 
-    def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+    def run_code(
+        self,
+        code: str,
+        language: str,
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         if language == "python":
-            return self._exec([sys.executable, "-c", code], workdir, timeout)
-        if language in ("node", "javascript"):
-            return self._exec(["node", "-e", code], workdir, timeout)
-        return ExecResult(stdout="", stderr=f"Unsupported language: {language}", exit_code=2)
+            argv = [sys.executable, "-c", code]
+        elif language in ("node", "javascript"):
+            argv = ["node", "-e", code]
+        else:
+            return ExecResult(stdout="", stderr=f"Unsupported language: {language}", exit_code=2)
+        return self._exec(argv, workdir, timeout, on_output=on_output, cancel_event=cancel_event)
 
 
 # ---------------------------------------------------------------------------
@@ -223,7 +385,15 @@ class ContainerRunner(SandboxRunner):
         ]
         return flags
 
-    def _run(self, image: str, inner_argv: list[str], workdir: Path, timeout: int) -> ExecResult:
+    def _run(
+        self,
+        image: str,
+        inner_argv: list[str],
+        workdir: Path,
+        timeout: int,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         workdir.mkdir(parents=True, exist_ok=True)
         before = snapshot_dir(workdir)
         argv = [
@@ -232,42 +402,59 @@ class ContainerRunner(SandboxRunner):
             image, *inner_argv,
         ]
         start = time.monotonic()
-        timed_out = False
         try:
-            proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
-            stdout, stderr, code = proc.stdout, proc.stderr, proc.returncode
-        except subprocess.TimeoutExpired as e:
-            timed_out = True
-            stdout = (e.stdout or "") if isinstance(e.stdout, str) else (e.stdout or b"").decode("utf-8", "replace")
-            stderr = ((e.stderr or "") if isinstance(e.stderr, str) else (e.stderr or b"").decode("utf-8", "replace"))
-            stderr += f"\n[timed out after {timeout}s]"
-            code = -1
+            raw = _run_popen(argv, workdir, timeout, on_output=on_output, cancel_event=cancel_event)
         except FileNotFoundError as e:
             return ExecResult(stdout="", stderr=f"Container engine not found: {e}", exit_code=127)
 
         return ExecResult(
-            stdout=_truncate(stdout), stderr=_truncate(stderr), exit_code=code,
-            timed_out=timed_out, duration_s=round(time.monotonic() - start, 3),
+            stdout=_truncate(raw.stdout), stderr=_truncate(raw.stderr), exit_code=raw.exit_code,
+            timed_out=raw.timed_out, cancelled=raw.cancelled,
+            duration_s=round(time.monotonic() - start, 3),
             artifacts=collect_artifacts(workdir, before),
         )
 
-    def run_command(self, argv: list[str], workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+    def run_command(
+        self,
+        argv: list[str],
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         # Normalize host shell wrappers (cmd /c, /bin/sh -c) to a container shell command.
         if len(argv) >= 3 and argv[0] in ("cmd", "/bin/sh", "sh") and argv[1] in ("/c", "-c"):
             command = argv[2]
         else:
             command = " ".join(argv)
-        return self._run(self.cfg["python_image"], ["sh", "-c", command], workdir, timeout)
+        return self._run(
+            self.cfg["python_image"], ["sh", "-c", command], workdir, timeout,
+            on_output=on_output, cancel_event=cancel_event,
+        )
 
-    def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+    def run_code(
+        self,
+        code: str,
+        language: str,
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         run_dir = workdir / ".phlox"
         run_dir.mkdir(parents=True, exist_ok=True)
         if language == "python":
             (run_dir / "run.py").write_text(code, encoding="utf-8")
-            return self._run(self.cfg["python_image"], ["python", "/work/.phlox/run.py"], workdir, timeout)
+            return self._run(
+                self.cfg["python_image"], ["python", "/work/.phlox/run.py"], workdir, timeout,
+                on_output=on_output, cancel_event=cancel_event,
+            )
         if language in ("node", "javascript"):
             (run_dir / "run.js").write_text(code, encoding="utf-8")
-            return self._run(self.cfg["node_image"], ["node", "/work/.phlox/run.js"], workdir, timeout)
+            return self._run(
+                self.cfg["node_image"], ["node", "/work/.phlox/run.js"], workdir, timeout,
+                on_output=on_output, cancel_event=cancel_event,
+            )
         return ExecResult(stdout="", stderr=f"Unsupported language: {language}", exit_code=2)
 
 
@@ -395,7 +582,11 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         )
 
     @staticmethod
-    def _consume(resp) -> dict:
+    def _consume(
+        resp,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> dict:
         """Drain an ``invoke_code_interpreter`` response into one result dict.
 
         The response carries an event stream under ``stream``; each ``result`` event has
@@ -403,11 +594,21 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         execute* tools) and ``result.content[]`` (MCP-style ``text``/``resource`` blocks,
         used by the file tools). Shapes verified against a live AgentCore Code Interpreter
         and the ``bedrock-agentcore`` botocore model.
+
+        ``on_output``/``cancel_event`` only matter for the execute* call sites: since AWS
+        already streams events as they're produced, forwarding each chunk live and bailing
+        out early on cancellation costs nothing extra here. There's no way to actually
+        interrupt the remote execution itself (no "kill" API for a live invoke), so
+        cancellation here just stops us from waiting on/reporting further output — the
+        remote call still runs to completion in the session.
         """
         out = {"stdout": "", "stderr": "", "exit_code": 0, "is_error": False,
-               "has_structured": False, "content": [], "text": ""}
+               "has_structured": False, "content": [], "text": "", "cancelled": False}
         text_parts: list[str] = []
         for event in resp.get("stream", []):
+            if cancel_event is not None and cancel_event.is_set():
+                out["cancelled"] = True
+                break
             result = event.get("result")
             if not result:
                 continue
@@ -416,8 +617,11 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             sc = result.get("structuredContent")
             if sc:
                 out["has_structured"] = True
-                out["stdout"] += sc.get("stdout") or ""
-                out["stderr"] += sc.get("stderr") or ""
+                chunk_out, chunk_err = sc.get("stdout") or "", sc.get("stderr") or ""
+                out["stdout"] += chunk_out
+                out["stderr"] += chunk_err
+                if on_output and (chunk_out or chunk_err):
+                    on_output(chunk_out + (f"[stderr] {chunk_err}" if chunk_err else ""))
                 if sc.get("exitCode") is not None:
                     try:
                         out["exit_code"] = int(sc["exitCode"])
@@ -427,6 +631,8 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                 out["content"].append(block)
                 if block.get("type") == "text" and block.get("text"):
                     text_parts.append(block["text"])
+                    if on_output:
+                        on_output(block["text"])
         # executeCommand returns terminal CRLF line endings; normalize to match the
         # local/container runners (plain \n) so output is consistent across runners.
         out["stdout"] = out["stdout"].replace("\r\n", "\n")
@@ -441,7 +647,7 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             if not p.is_file():
                 continue
             rel = p.relative_to(workdir)
-            if any(part in _IGNORE_DIRS for part in rel.parts):
+            if any(part in IGNORE_DIRS for part in rel.parts):
                 continue
             try:
                 if p.stat().st_size > self.max_sync_bytes:
@@ -505,7 +711,7 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
             name = block.get("name")
             if not name or "/" in name or name in (".", ".."):
                 continue
-            if name in _IGNORE_DIRS:
+            if name in IGNORE_DIRS:
                 continue
             if depth == 0 and name in baseline:
                 continue  # interpreter-internal / pre-existing entry — not ours
@@ -567,7 +773,14 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                 logger.warning("AgentCore write_back %s failed: %s", rel, exc)
 
     # -- SandboxRunner interface --------------------------------------------
-    def run_command(self, argv: list[str], workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+    def run_command(
+        self,
+        argv: list[str],
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         # Normalize host shell wrappers (cmd /c, /bin/sh -c) to a single command string.
         if len(argv) >= 3 and argv[0] in ("cmd", "/bin/sh", "sh") and argv[1] in ("/c", "-c"):
             command = argv[2]
@@ -576,10 +789,20 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         return self._run(
             lambda sid: self._invoke(sid, "executeCommand", {"command": command}),
             workdir,
-            lambda: self._fallback.run_command(argv, workdir, timeout),
+            lambda: self._fallback.run_command(argv, workdir, timeout, on_output=on_output, cancel_event=cancel_event),
+            on_output=on_output,
+            cancel_event=cancel_event,
         )
 
-    def run_code(self, code: str, language: str, workdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ExecResult:
+    def run_code(
+        self,
+        code: str,
+        language: str,
+        workdir: Path,
+        timeout: int = DEFAULT_TIMEOUT,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         if language == "python":
             lang = "python"
         elif language in ("node", "javascript"):
@@ -591,17 +814,26 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
         return self._run(
             lambda sid: self._invoke(sid, "executeCode", {"language": lang, "code": code}),
             workdir,
-            lambda: self._fallback.run_code(code, language, workdir, timeout),
+            lambda: self._fallback.run_code(code, language, workdir, timeout, on_output=on_output, cancel_event=cancel_event),
+            on_output=on_output,
+            cancel_event=cancel_event,
         )
 
-    def _run(self, do_invoke, workdir: Path, fallback) -> ExecResult:
+    def _run(
+        self,
+        do_invoke,
+        workdir: Path,
+        fallback,
+        on_output: OutputCallback | None = None,
+        cancel_event: threading.Event | None = None,
+    ) -> ExecResult:
         workdir.mkdir(parents=True, exist_ok=True)
         start = time.monotonic()
         try:
             sid = self._session_for(workdir)
             before = snapshot_dir(workdir)
             self._sync_in(sid, workdir)
-            res = self._consume(do_invoke(sid))
+            res = self._consume(do_invoke(sid), on_output=on_output, cancel_event=cancel_event)
             self._sync_out(sid, workdir)
             if res["has_structured"]:
                 # execute* tools: trust the clean structuredContent split.
@@ -617,6 +849,7 @@ class AgentCoreCodeInterpreterRunner(SandboxRunner):
                 stdout=_truncate(stdout),
                 stderr=_truncate(stderr),
                 exit_code=exit_code,
+                cancelled=res.get("cancelled", False),
                 duration_s=round(time.monotonic() - start, 3),
                 artifacts=collect_artifacts(workdir, before),
             )

--- a/backend/app/workspace/checkpoints.py
+++ b/backend/app/workspace/checkpoints.py
@@ -11,12 +11,31 @@ from __future__ import annotations
 
 import logging
 import subprocess
+import threading
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _GIT_ENV = {"GIT_AUTHOR_NAME": "Phlox", "GIT_AUTHOR_EMAIL": "agent@phlox.local",
             "GIT_COMMITTER_NAME": "Phlox", "GIT_COMMITTER_EMAIL": "agent@phlox.local"}
+
+# One lock per workspace, serializing git operations against that workspace's repo.
+# Needed now that concurrent sub-agents can mutate the same workspace in parallel
+# (see spawn_subagent) — two concurrent `git add -A && git commit` calls against the
+# same repo race on the index/lock file and can corrupt or fail unpredictably.
+# RLock because restore_checkpoint calls create_checkpoint while already holding it.
+_locks: dict[str, threading.RLock] = {}
+_locks_guard = threading.Lock()
+
+
+def _lock_for(workspace: Path) -> threading.RLock:
+    key = str(workspace)
+    with _locks_guard:
+        lock = _locks.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _locks[key] = lock
+        return lock
 
 
 def _git(workspace: Path, *args: str, check: bool = False) -> subprocess.CompletedProcess:
@@ -54,19 +73,20 @@ def ensure_repo(workspace: Path) -> bool:
 
 def create_checkpoint(workspace: Path, label: str) -> str | None:
     """Commit the current workspace state. Returns the short sha, or None if unchanged/failed."""
-    if not ensure_repo(workspace):
-        return None
-    try:
-        _git(workspace, "add", "-A")
-        status = _git(workspace, "status", "--porcelain")
-        if not status.stdout.strip():
-            return None  # nothing changed since last checkpoint
-        _git(workspace, "commit", "-m", label, "-q")
-        sha = _git(workspace, "rev-parse", "--short", "HEAD").stdout.strip()
-        return sha or None
-    except Exception as e:  # noqa: BLE001
-        logger.warning("checkpoint failed: %s", e)
-        return None
+    with _lock_for(workspace):
+        if not ensure_repo(workspace):
+            return None
+        try:
+            _git(workspace, "add", "-A")
+            status = _git(workspace, "status", "--porcelain")
+            if not status.stdout.strip():
+                return None  # nothing changed since last checkpoint
+            _git(workspace, "commit", "-m", label, "-q")
+            sha = _git(workspace, "rev-parse", "--short", "HEAD").stdout.strip()
+            return sha or None
+        except Exception as e:  # noqa: BLE001
+            logger.warning("checkpoint failed: %s", e)
+            return None
 
 
 def list_checkpoints(workspace: Path) -> list[dict]:
@@ -86,14 +106,15 @@ def list_checkpoints(workspace: Path) -> list[dict]:
 
 def restore_checkpoint(workspace: Path, sha: str) -> bool:
     """Restore the working tree to a snapshot (without losing later history)."""
-    if not (workspace / ".git").exists():
-        return False
-    try:
-        # Record current state first so nothing is lost.
-        create_checkpoint(workspace, "before restore")
-        _git(workspace, "restore", "--source", sha, "--worktree", "--", ".", check=True)
-        create_checkpoint(workspace, f"restored {sha}")
-        return True
-    except Exception as e:  # noqa: BLE001
-        logger.warning("restore failed: %s", e)
-        return False
+    with _lock_for(workspace):
+        if not (workspace / ".git").exists():
+            return False
+        try:
+            # Record current state first so nothing is lost.
+            create_checkpoint(workspace, "before restore")
+            _git(workspace, "restore", "--source", sha, "--worktree", "--", ".", check=True)
+            create_checkpoint(workspace, f"restored {sha}")
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.warning("restore failed: %s", e)
+            return False

--- a/backend/config.yml.example
+++ b/backend/config.yml.example
@@ -11,8 +11,8 @@
 # (Settings → Admin → Configuration), with no restart: provider `profiles`, model `pricing`,
 # `resilience`, generation `defaults`, and the sandbox container *limits*. Those overrides
 # are stored in the database and take precedence over this file. The sections that stay
-# file-only (for bootstrap/security): `auth` (incl. jwt_secret), `vector_store`, the sandbox
-# `runner` *type*, and `observability.otel`/`request_logging`.
+# file-only (for bootstrap/security): `auth` (incl. jwt_secret), `vector_store`, `web_fetch`,
+# the sandbox `runner` *type*, and `observability.otel`/`request_logging`.
 
 # Which profile is active on first launch (can be changed in the UI afterwards).
 default_profile: local-ollama
@@ -153,6 +153,20 @@ resilience:
 # Optional: point at a SearXNG instance with JSON output enabled.
 web_search:
   searxng_url: ""              # e.g. http://localhost:8080 (or set SEARXNG_URL)
+
+# web_fetch SSRF guard. FILE-ONLY (not in the admin UI — like the sandbox runner type,
+# loosening this at runtime would be a security surprise). By default `web_fetch` refuses
+# to reach private/loopback/link-local addresses (incl. the cloud metadata IP,
+# 169.254.169.254), so a prompt can't use the agent as a pivot into your internal network.
+web_fetch:
+  allow_private_networks: false   # true disables the guard entirely (fetch any address)
+  # Hostnames, IPs, or CIDR ranges allowed through the guard even though they're
+  # private/internal — e.g. an internal API you want the agent to be able to call.
+  allowlist_hosts: []
+  # allowlist_hosts:
+  #   - "internal-api.corp.local"
+  #   - "10.0.5.20"
+  #   - "192.168.1.0/24"
 
 # Code/shell execution sandbox.
 #   runner: local      -> run on the host (fast, trusts the host; fine for single-user/dev)

--- a/backend/tests/test_checkpoints_concurrency.py
+++ b/backend/tests/test_checkpoints_concurrency.py
@@ -1,0 +1,62 @@
+"""Concurrent checkpoint creation must not corrupt the workspace's git repo.
+
+Regression test for the per-workspace lock added to app.workspace.checkpoints: before it,
+two threads calling create_checkpoint at the same time (e.g. two sub-agents mutating files
+in parallel) raced on `git add -A && git commit` against the same index/lock file.
+"""
+import threading
+
+from app.workspace import checkpoints
+
+
+def test_concurrent_create_checkpoint_does_not_corrupt_repo(tmp_path):
+    if not checkpoints.git_available():
+        return  # environment has no git; nothing to test
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    checkpoints.ensure_repo(workspace)
+
+    errors: list[Exception] = []
+
+    def worker(n: int) -> None:
+        try:
+            (workspace / f"file{n}.txt").write_text(f"content {n}")
+            checkpoints.create_checkpoint(workspace, f"from thread {n}")
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors
+    assert not any(t.is_alive() for t in threads)
+
+    # The repo is intact and every file made it into some checkpoint.
+    rows = checkpoints.list_checkpoints(workspace)
+    assert len(rows) >= 1
+    for n in range(8):
+        assert (workspace / f"file{n}.txt").exists()
+
+
+def test_restore_checkpoint_is_reentrant_with_its_own_lock(tmp_path):
+    # restore_checkpoint acquires the workspace lock, then calls create_checkpoint
+    # (twice) while still holding it — must not deadlock (requires an RLock).
+    workspace = tmp_path / "ws2"
+    workspace.mkdir()
+    if not checkpoints.ensure_repo(workspace):
+        return
+
+    (workspace / "a.txt").write_text("v1")
+    sha = checkpoints.create_checkpoint(workspace, "v1")
+    assert sha
+
+    (workspace / "a.txt").write_text("v2")
+    checkpoints.create_checkpoint(workspace, "v2")
+
+    ok = checkpoints.restore_checkpoint(workspace, sha)
+    assert ok
+    assert (workspace / "a.txt").read_text() == "v1"

--- a/backend/tests/test_harness.py
+++ b/backend/tests/test_harness.py
@@ -1,4 +1,7 @@
 """Integration/eval tests for the agent loop using scripted fake providers."""
+import threading
+import time
+
 from app.providers.base import StreamDelta, ToolCall
 
 
@@ -60,6 +63,31 @@ class UnexpectedToolProvider:
             )
         else:
             yield StreamDelta(type="text", text="Done.")
+            yield StreamDelta(type="done", stop_reason="stop")
+
+
+class ShellProvider:
+    """Round 1: request run_shell with a caller-supplied command. Round 2: final text."""
+
+    model = "shell-scripted"
+    supports_tools = True
+
+    def __init__(self, command: str, timeout: int = 60):
+        self.command = command
+        self.timeout = timeout
+        self.round = 0
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        self.round += 1
+        if self.round == 1:
+            yield StreamDelta(
+                type="tool_calls",
+                tool_calls=[
+                    ToolCall(id="c1", name="run_shell", arguments={"command": self.command, "timeout": self.timeout})
+                ],
+            )
+        else:
+            yield StreamDelta(type="text", text="Ran it.")
             yield StreamDelta(type="done", stop_reason="stop")
 
 
@@ -125,3 +153,114 @@ def test_allowed_tools_denies_unadvertised_tool_calls(db):
 
     assert "web_search" in events
     assert "not enabled for this turn" in events
+
+
+def test_tool_progress_events_stream_live_shell_output(db):
+    conv = _new_conversation(db)
+    session = _session(db, conv, ShellProvider("echo hello-world"))
+    events = "".join(session.run([{"role": "system", "content": "s"},
+                                  {"role": "user", "content": "run it"}]))
+
+    assert "tool_progress" in events
+    assert "hello-world" in events
+
+
+def test_cancel_event_set_before_run_skips_provider_entirely(db):
+    # If the turn is already cancelled before the first round, the loop must finalize
+    # without ever calling the model (and without hanging).
+    conv = _new_conversation(db)
+    provider = ScriptedProvider()
+    cancel = threading.Event()
+    cancel.set()
+    session = _session(db, conv, provider, cancel_event=cancel)
+
+    events = "".join(session.run([{"role": "system", "content": "s"},
+                                  {"role": "user", "content": "hi"}]))
+
+    assert provider.round == 0
+    assert '"type": "done"' in events
+
+
+def test_cancel_event_kills_in_flight_shell_command_promptly(db):
+    # Regression test: cancelling a turn must actually kill the running subprocess (and
+    # its children) rather than leaving the harness blocked until the command's own
+    # timeout — see the process-tree-kill fix in app.sandbox.runner.
+    conv = _new_conversation(db)
+    cancel = threading.Event()
+    provider = ShellProvider("echo start; sleep 5; echo end", timeout=30)
+    session = _session(db, conv, provider, cancel_event=cancel)
+
+    def canceller():
+        time.sleep(0.3)
+        cancel.set()
+
+    threading.Thread(target=canceller, daemon=True).start()
+
+    start = time.monotonic()
+    events = "".join(session.run([{"role": "system", "content": "s"},
+                                  {"role": "user", "content": "run it"}]))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 3.0, f"cancellation took {elapsed:.1f}s — the child process wasn't killed promptly"
+    assert "start" in events
+    # "end" appears once already, in the echoed tool-call arguments (the command string
+    # itself) — it must not appear again as actual output, which would mean the sleep
+    # (and the echo after it) ran to completion instead of being killed.
+    assert events.count("end") == 1
+    assert "cancelled" in events.lower()
+
+
+class TwoSubagentsProvider:
+    """Round 1: request two spawn_subagent calls at once. Round 2: final text."""
+
+    model = "two-subagents"
+    supports_tools = True
+
+    def __init__(self):
+        self.round = 0
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        self.round += 1
+        if self.round == 1:
+            yield StreamDelta(
+                type="tool_calls",
+                tool_calls=[
+                    ToolCall(id="c1", name="spawn_subagent", arguments={"task": "task A"}),
+                    ToolCall(id="c2", name="spawn_subagent", arguments={"task": "task B"}),
+                ],
+            )
+        else:
+            yield StreamDelta(type="text", text="Both done.")
+            yield StreamDelta(type="done", stop_reason="stop")
+
+
+class SlowSubagentProvider:
+    """Stands in for each sub-agent's own model call: takes a bit of real wall-clock
+    time, so sequential-vs-concurrent execution is distinguishable by elapsed time."""
+
+    model = "slow-subagent"
+    supports_tools = True
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        time.sleep(0.3)
+        yield StreamDelta(type="text", text="subagent result")
+        yield StreamDelta(type="done", stop_reason="stop")
+
+
+def test_concurrent_spawn_subagent_calls_run_in_parallel(db, monkeypatch):
+    # Regression test for the fix in AgentSession._run_calls_concurrently: two
+    # spawn_subagent calls requested in the same round used to run one after another;
+    # they should now run in parallel worker threads.
+    conv = _new_conversation(db)
+    monkeypatch.setattr(
+        "app.providers.registry.build_provider", lambda profile, model=None: SlowSubagentProvider()
+    )
+
+    session = _session(db, conv, TwoSubagentsProvider())
+    start = time.monotonic()
+    events = "".join(session.run([{"role": "system", "content": "s"},
+                                  {"role": "user", "content": "do both"}]))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.55, f"took {elapsed:.2f}s — looks sequential (2x0.3s), not concurrent"
+    assert events.count("subagent result") == 2

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -1,0 +1,116 @@
+"""Unit tests for the permission gate — the harness's security seam.
+
+Covers: policy resolution (auto/ask/deny), the disabled-tool override, and the
+``interactive`` flag that keeps an unattended sub-agent from either silently bypassing
+"ask" tools or hanging on an approval pause nobody can answer.
+
+Each test builds its own registry with uniquely-named tools and seeds ``ToolPref`` rows
+from scratch, since the ``db`` fixture shares one sqlite file for the whole test session
+(no per-test rollback) — reusing a tool name across tests would collide on the
+``tool_prefs`` primary key or leak state between tests.
+"""
+import itertools
+
+from app.agent.permissions import PermissionGate, seed_tool_prefs
+from app.agent.registry import ToolRegistry
+from app.agent.tools.base import Tool
+
+_counter = itertools.count()
+
+
+def _tool(default_permission: str) -> Tool:
+    name = f"test_tool_{default_permission}_{next(_counter)}"
+
+    class _T(Tool):
+        pass
+
+    _T.name = name
+    _T.default_permission = default_permission
+    return _T()
+
+
+def _seeded_gate(db, tools: list[Tool], **kw) -> tuple[PermissionGate, list[str]]:
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    seed_tool_prefs(db, reg)
+    return PermissionGate(db, reg, **kw), [t.name for t in tools]
+
+
+def test_decide_auto_policy_allows(db):
+    tool = _tool("auto")
+    gate, _ = _seeded_gate(db, [tool])
+    assert gate.decide(tool.name) == "allow"
+
+
+def test_decide_deny_policy_always_denies(db):
+    tool = _tool("deny")
+    gate, _ = _seeded_gate(db, [tool], auto_approve=True)
+    assert gate.decide(tool.name) == "deny"
+
+
+def test_decide_unregistered_tool_defaults_to_allow(db):
+    # No ToolPref row and not in this registry: decide() falls back to policy "auto".
+    gate, _ = _seeded_gate(db, [])
+    assert gate.decide("nonexistent_tool") == "allow"
+
+
+def test_decide_ask_policy_pauses_when_interactive_and_not_auto_approved(db):
+    tool = _tool("ask")
+    gate, _ = _seeded_gate(db, [tool], auto_approve=False, interactive=True)
+    assert gate.decide(tool.name) == "ask"
+
+
+def test_decide_ask_policy_allows_when_auto_approved(db):
+    tool = _tool("ask")
+    gate, _ = _seeded_gate(db, [tool], auto_approve=True, interactive=True)
+    assert gate.decide(tool.name) == "allow"
+
+
+def test_decide_ask_policy_denies_when_not_interactive_and_not_auto_approved(db):
+    # This is the sub-agent case: nobody can answer an approval pause, so "ask" must not
+    # silently become "allow" (a permission bypass) or hang (a broken turn) — it must
+    # become "deny".
+    tool = _tool("ask")
+    gate, _ = _seeded_gate(db, [tool], auto_approve=False, interactive=False)
+    assert gate.decide(tool.name) == "deny"
+
+
+def test_decide_ask_policy_still_allows_when_auto_approved_and_not_interactive(db):
+    # auto_approve reflects the *parent turn's* real setting, so it still wins even in a
+    # non-interactive (sub-agent) gate.
+    tool = _tool("ask")
+    gate, _ = _seeded_gate(db, [tool], auto_approve=True, interactive=False)
+    assert gate.decide(tool.name) == "allow"
+
+
+def test_disabled_tool_pref_overrides_policy_to_deny(db):
+    from app.models import ToolPref
+
+    tool = _tool("auto")
+    reg = ToolRegistry()
+    reg.register(tool)
+    seed_tool_prefs(db, reg)
+    db.get(ToolPref, tool.name).enabled = False
+    db.commit()
+
+    gate = PermissionGate(db, reg)
+    assert gate.decide(tool.name) == "deny"
+
+
+def test_enabled_names_excludes_denied_and_disabled_tools(db):
+    from app.models import ToolPref
+
+    auto_tool, ask_tool, deny_tool = _tool("auto"), _tool("ask"), _tool("deny")
+    reg = ToolRegistry()
+    for t in (auto_tool, ask_tool, deny_tool):
+        reg.register(t)
+    seed_tool_prefs(db, reg)
+    db.get(ToolPref, auto_tool.name).enabled = False
+    db.commit()
+
+    gate = PermissionGate(db, reg)  # constructed after the mutation, so it sees it
+    enabled = gate.enabled_names()
+    assert auto_tool.name not in enabled  # disabled
+    assert deny_tool.name not in enabled  # policy=deny
+    assert ask_tool.name in enabled       # ask is still "enabled", just gated at call time

--- a/backend/tests/test_subagent.py
+++ b/backend/tests/test_subagent.py
@@ -1,0 +1,77 @@
+"""Sub-agent must inherit the parent turn's real approval state, not grant itself a
+permission bypass. Regression test for the fix in app.agent.tools.subagent.SpawnSubagent:
+it used to hardcode PermissionGate(auto_approve=True), so approving a single
+spawn_subagent call silently unlocked every ask-tier tool (run_shell, write_file, ...)
+inside it, regardless of what the user actually approved for the turn.
+"""
+from app.agent.permissions import seed_tool_prefs
+from app.agent.registry import REGISTRY
+from app.agent.tools.base import ToolContext
+from app.agent.tools.subagent import SpawnSubagent
+from app.models import Conversation
+from app.providers.base import StreamDelta, ToolCall
+from app.sandbox.runner import get_runner
+from app.workspace.manager import workspace_dir
+
+
+class _RequestsShellThenAnswers:
+    """Round 1: ask to run a shell command. Round 2: report what happened."""
+
+    model = "scripted-sub"
+    supports_tools = True
+
+    def __init__(self):
+        self.round = 0
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        self.round += 1
+        if self.round == 1:
+            yield StreamDelta(
+                type="tool_calls",
+                tool_calls=[ToolCall(id="c1", name="run_shell", arguments={"command": "echo hi"})],
+            )
+        else:
+            # Echo the tool result back so the test can assert on it.
+            last_tool_msg = next(m for m in reversed(messages) if m["role"] == "tool")
+            yield StreamDelta(type="text", text=f"result: {last_tool_msg['content']}")
+            yield StreamDelta(type="done", stop_reason="stop")
+
+
+def _new_conversation(db):
+    conv = Conversation(title="t", user_id="local")
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+
+def _run_subagent(db, monkeypatch, *, auto_approve: bool) -> str:
+    seed_tool_prefs(db, REGISTRY)  # run_shell -> permission="ask" (its default)
+    conv = _new_conversation(db)
+
+    monkeypatch.setattr(
+        "app.providers.registry.build_provider", lambda profile, model=None: _RequestsShellThenAnswers()
+    )
+
+    ctx = ToolContext(
+        conversation_id=conv.id,
+        workspace=workspace_dir(conv.id),
+        db=db,
+        runner=get_runner(),
+        user_id=None,
+        auto_approve=auto_approve,
+    )
+    result = SpawnSubagent().run(ctx, task="run a shell command")
+    return result.content
+
+
+def test_subagent_denies_ask_tier_tool_when_parent_turn_is_not_auto_approving(db, monkeypatch):
+    content = _run_subagent(db, monkeypatch, auto_approve=False)
+    assert "denied" in content.lower()
+    assert "not executed" in content.lower()
+
+
+def test_subagent_allows_ask_tier_tool_when_parent_turn_is_auto_approving(db, monkeypatch):
+    content = _run_subagent(db, monkeypatch, auto_approve=True)
+    assert "exit 0" in content.lower()
+    assert "denied" not in content.lower()

--- a/backend/tests/test_web_fetch_ssrf.py
+++ b/backend/tests/test_web_fetch_ssrf.py
@@ -1,0 +1,54 @@
+"""Tests for the web_fetch SSRF guard (blocks private/loopback/link-local targets)."""
+from app.agent.tools.web import _host_allowlisted, _is_blocked_ip, _ssrf_guard
+
+
+def test_is_blocked_ip_flags_private_and_loopback_and_metadata():
+    assert _is_blocked_ip("10.0.0.5")
+    assert _is_blocked_ip("172.16.0.1")
+    assert _is_blocked_ip("192.168.1.1")
+    assert _is_blocked_ip("127.0.0.1")
+    assert _is_blocked_ip("169.254.169.254")  # cloud metadata endpoint
+    assert _is_blocked_ip("::1")
+    assert _is_blocked_ip("fc00::1")  # IPv6 unique local
+
+
+def test_is_blocked_ip_allows_public_ip():
+    assert not _is_blocked_ip("8.8.8.8")
+
+
+def test_is_blocked_ip_fails_closed_on_garbage():
+    assert _is_blocked_ip("not-an-ip")
+
+
+def test_host_allowlisted_matches_hostname_and_cidr():
+    assert _host_allowlisted("internal.example.com", ["internal.example.com"])
+    assert _host_allowlisted("10.0.0.5", ["10.0.0.0/8"])
+    assert not _host_allowlisted("10.0.0.5", ["192.168.0.0/16"])
+    assert not _host_allowlisted("evil.example.com", ["internal.example.com"])
+
+
+def test_ssrf_guard_blocks_loopback_url():
+    assert _ssrf_guard("http://127.0.0.1/admin") is not None
+
+
+def test_ssrf_guard_blocks_metadata_ip():
+    assert _ssrf_guard("http://169.254.169.254/latest/meta-data/") is not None
+
+
+def test_ssrf_guard_allows_url_with_no_private_resolution(monkeypatch):
+    # Avoid a real DNS lookup in CI: stub getaddrinfo to resolve to a public IP.
+    import socket
+
+    monkeypatch.setattr(
+        socket, "getaddrinfo", lambda *a, **k: [(2, 1, 6, "", ("93.184.216.34", 0))]
+    )
+    assert _ssrf_guard("http://example.com/") is None
+
+
+def test_ssrf_guard_respects_allow_private_networks_config(monkeypatch):
+    from app.agent.tools import web as web_module
+
+    monkeypatch.setattr(
+        web_module, "get_web_fetch_config", lambda: {"allow_private_networks": True, "allowlist_hosts": []}
+    )
+    assert _ssrf_guard("http://127.0.0.1/admin") is None

--- a/backend/tests/test_workspace_manager.py
+++ b/backend/tests/test_workspace_manager.py
@@ -1,0 +1,32 @@
+"""Tests for the workspace path-traversal guard used by every filesystem/shell/code tool."""
+import pytest
+
+from app.workspace.manager import resolve_in_workspace, workspace_dir
+
+
+def test_resolve_in_workspace_allows_nested_path():
+    conv_id = "test-conv-nested"
+    p = resolve_in_workspace(conv_id, "sub/dir/file.txt")
+    # .resolve() on both sides: on macOS workspace_dir() may return a path through a
+    # symlink (e.g. /var -> /private/var) that only resolve_in_workspace canonicalizes.
+    assert p == (workspace_dir(conv_id) / "sub" / "dir" / "file.txt").resolve()
+
+
+def test_resolve_in_workspace_allows_dot():
+    conv_id = "test-conv-dot"
+    assert resolve_in_workspace(conv_id, ".") == workspace_dir(conv_id).resolve()
+
+
+@pytest.mark.parametrize(
+    "escape_path",
+    [
+        "../escape.txt",
+        "../../etc/passwd",
+        "sub/../../escape.txt",
+        "..\\escape.txt",  # Windows-style traversal must be rejected on every host
+        "/etc/passwd",
+    ],
+)
+def test_resolve_in_workspace_rejects_traversal(escape_path):
+    with pytest.raises(ValueError, match="escapes workspace"):
+        resolve_in_workspace("test-conv-escape", escape_path)

--- a/docs/ADDING_A_TOOL.md
+++ b/docs/ADDING_A_TOOL.md
@@ -38,7 +38,22 @@ class WordCount(Tool):
 - `ctx.conversation_id` — the conversation
 - `ctx.workspace` — `Path` to the per-conversation working dir (sandbox root)
 - `ctx.db` — a SQLAlchemy `Session`
+- `ctx.user_id` — the owning user, or `None` when auth is disabled
 - `ctx.runner` — the `SandboxRunner` (use for executing commands/code)
+- `ctx.auto_approve` — whether the current turn has "Agent mode" on. If your tool
+  delegates to a nested `AgentSession` (like `spawn_subagent`), pass this through rather
+  than hardcoding a policy — don't let a tool grant itself permissions the user didn't
+  give the turn.
+- `ctx.progress` — `Callable[[str], None] | None`. For a long-running tool, call it with
+  each chunk of output as you produce it and it streams to the UI live as a
+  `tool_progress` event instead of only appearing when `run` returns. `run_shell` /
+  `execute_python` / `execute_node` forward it to `ctx.runner.run_command`/`run_code` as
+  `on_output=ctx.progress` — follow that pattern for anything wrapping a subprocess.
+- `ctx.cancel_event` — `threading.Event | None`, set when the turn is cancelled (timeout
+  or the user's Stop). A long-running tool should poll it and stop promptly; pass it
+  through to `ctx.runner.run_command`/`run_code` as `cancel_event=ctx.cancel_event` if
+  you're wrapping a subprocess — the local/container runners already kill the whole
+  process tree when it's set, not just the immediate child.
 
 ### `ToolResult` fields
 - `content: str` — text the model sees (keep it bounded; large outputs get truncated)
@@ -78,6 +93,12 @@ That's it. On next startup the tool is registered, a `ToolPref` row is seeded wi
 - `deny` tools never run.
 
 Mutating or executing tools should default to `ask`. Read-only tools can be `auto`.
+
+If your tool is only ever driven by an unattended nested session (there's no human to
+answer an approval pause — `spawn_subagent` is the only current example), build its
+`PermissionGate` with `interactive=False`. That makes `ask` resolve to `deny` instead of
+either hanging on an unanswerable pause or silently becoming `allow` — an unattended
+tool call must never grant itself a permission the surrounding turn didn't have.
 
 Some built-in tools also need per-turn user intent, not just a global tool preference.
 For those, keep the tool registered normally, but pass an `allowed_tools` set into

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,18 +98,32 @@ deals with provider-specific shapes.
 - **Permission gate is the security seam** (`agent/permissions.py`). Each tool has a
   default policy (`auto|ask|deny`); read-only tools are `auto`, mutating/exec tools are
   `ask`. "Agent mode" in the composer sets `auto_approve`, which promotes `ask`→`allow`
-  for that turn. Users override per-tool in the Tool Manager (persisted in `ToolPref`).
+  for that turn. Users override per-tool in the Tool Manager (persisted in `ToolPref`). A
+  second flag, `interactive`, covers *unattended* execution (sub-agents — see below): with
+  no human able to answer an approval pause, `ask` resolves to `deny` there instead of
+  either hanging or silently becoming `allow`.
 - **Live web and document-library search are opt-in per prompt.** `web_search` and
   `search_documents` are registered like other tools, but `routers/chat.py` passes an
   `allowed_tools` set to `AgentSession` and removes them unless the composer request opts
   in (`web_search: true`, `document_search: true`) or the user directly references a
   document on the message. Web search uses ddgs by default and can use SearXNG via
-  `web_search.searxng_url` / `SEARXNG_URL`.
+  `web_search.searxng_url` / `SEARXNG_URL`. `web_fetch` has an **SSRF guard**
+  (`agent/tools/web.py::_ssrf_guard`): by default it refuses to reach private/loopback/
+  link-local addresses (incl. the cloud metadata IP), re-checked on every redirect hop so a
+  public host can't 302 its way to an internal one. File-only via `web_fetch` in
+  `config.yml` (`allow_private_networks`, `allowlist_hosts`) — not admin-UI-editable, same
+  reasoning as the sandbox runner type.
 - **Sandbox is a swappable interface** (`sandbox/runner.py`). `LocalSubprocessRunner`
-  (host, fast) and `ContainerRunner` (ephemeral Podman/Docker container with CPU/mem/PID
-  limits + network isolation, workspace bind-mounted) are selected by `sandbox.runner` in
-  `config.yml`. The container runner targets the Docker-compatible CLI, so Podman (incl.
-  Docker-compat mode) and Docker both work across Windows/macOS/Linux.
+  (host, fast), `ContainerRunner` (ephemeral Podman/Docker container with CPU/mem/PID
+  limits + network isolation, workspace bind-mounted), and `AgentCoreCodeInterpreterRunner`
+  (off-host AWS Bedrock microVM) are selected by `sandbox.runner` in `config.yml`. The
+  container runner targets the Docker-compatible CLI, so Podman (incl. Docker-compat mode)
+  and Docker both work across Windows/macOS/Linux. All three stream live stdout/stderr back
+  as `tool_progress` SSE events while a command runs (instead of only at the end), and all
+  three honor a per-turn `cancel_event`: a timeout or a user's "Stop" click kills the whole
+  process **tree**, not just the immediate child — a shell that forked a build/test process
+  no longer keeps running as an orphan after the tool call is reported as timed
+  out/cancelled. See [SANDBOX.md](SANDBOX.md) §"Live output & cancellation".
 - **Auth & multi-user.** Local username/password (bcrypt) + JWT sessions, with an Entra ID
   OIDC seam for production SSO. `get_current_user`/`require_admin` gate requests; data
   (conversations, documents, memories, settings) is scoped strictly per `user_id` —
@@ -137,10 +151,19 @@ deals with provider-specific shapes.
   `AgentSession` (doesn't persist to the parent conversation) with a scoped toolset in the
   **same workspace**, and returns its report. `AgentSession` gained `ephemeral` +
   `allowed_tools` for this. Recursion is prevented by excluding `spawn_subagent` from the
-  child's tools.
+  child's tools. It **inherits the parent turn's real approval state** rather than granting
+  itself a bypass (`auto_approve=ctx.auto_approve`, `interactive=False` — see the
+  permission-gate bullet above), and it opens its **own DB session** rather than sharing
+  `ctx.db`, since a SQLAlchemy session isn't safe across threads. That isolation is what
+  lets `AgentSession._run_calls_concurrently` run **multiple `spawn_subagent` calls from
+  the same round in parallel** worker threads instead of one after another — the model
+  decomposing a task into independent chunks actually saves wall-clock time now, not just
+  context budget. Everything else in a round still executes sequentially.
 - **Checkpoints** (`workspace/checkpoints.py`): each workspace is a git repo; the harness
   auto-snapshots after a successful mutating tool (`MUTATING_TOOLS`), and the user can
-  restore any snapshot (current state is snapshotted first, so nothing is lost).
+  restore any snapshot (current state is snapshotted first, so nothing is lost). A
+  per-workspace `RLock` serializes the actual git operations, since concurrent sub-agents
+  (above) can now mutate + checkpoint the same workspace at the same time.
 - **Multimodal** (`attachments.py`, providers): images attach to a user message (base64
   data URLs), are persisted to `data/attachments/<msg>/` and replayed into the provider as
   image content parts for vision models. The OpenAI provider also surfaces `reasoning`
@@ -233,8 +256,9 @@ Three layers, each with a clear job:
 
 - **`backend/config.yml`** (from `config.yml.example`): the **seed / bootstrap**. Provider
   `profiles`, `defaults`, `embeddings`, plus bootstrap-or-security-sensitive sections that
-  stay file-only: `auth` (incl. `jwt_secret`), `vector_store`, and
-  `observability.otel`/`request_logging`. Loaded + cached in `config.py` (`@lru_cache`).
+  stay file-only: `auth` (incl. `jwt_secret`), `vector_store`, `web_fetch` (the SSRF-guard
+  allowlist), and `observability.otel`/`request_logging`. Loaded + cached in `config.py`
+  (`@lru_cache`).
 - **Deployment overrides** (DB `AppConfig` table, `app_config.py`): admin-edited, **live**
   overrides for a curated set of sections — provider `profiles`, model `pricing`,
   `resilience`, generation defaults, and sandbox **limits**. The getters in `config.py`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,16 +22,34 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
   wired in `routers/chat.py`.
 - [x] **Planning + sub-agents.** `update_todos` (plan tool, persisted per workspace) and
   `spawn_subagent` (nested ephemeral `AgentSession` with a scoped toolset in the shared
-  workspace, returns a report). _Implemented in:_ `agent/tools/planning.py`,
-  `agent/tools/subagent.py`, `agent/harness.py` (ephemeral + `allowed_tools`).
+  workspace, returns a report). It inherits the parent turn's real approval state instead
+  of granting itself one (`interactive=False` in `PermissionGate` — ask-tier tools deny
+  rather than hang/bypass when unattended), and opens its own DB session so multiple
+  `spawn_subagent` calls in the same round can run **concurrently** in worker threads
+  instead of one after another. _Implemented in:_ `agent/tools/planning.py`,
+  `agent/tools/subagent.py`, `agent/harness.py` (ephemeral + `allowed_tools` +
+  `_run_calls_concurrently`), `agent/permissions.py` (`interactive`).
 - [x] **Workspace checkpointing / undo.** Each workspace is a git repo; mutating tools
   auto-snapshot after running; list/restore via tools, `/api/checkpoints`, and the header
-  History modal. _Implemented in:_ `workspace/checkpoints.py`,
-  `agent/tools/checkpoint.py`, `routers/checkpoints.py`, `components/chat/CheckpointsModal.jsx`.
-- [x] **Steering & follow-up queue.** Type while a turn is streaming to queue a follow-up
-  that auto-sends when the turn finishes; Stop + the approval pause/resume cover
-  interruption. _Implemented in:_ store `queued`/`resolveApproval`, `Composer.jsx`.
-  (True token-level mid-run injection is out of scope for the SSE model.)
+  History modal. A per-workspace `RLock` serializes the git operations now that concurrent
+  sub-agents can checkpoint the same workspace at once. _Implemented in:_
+  `workspace/checkpoints.py`, `agent/tools/checkpoint.py`, `routers/checkpoints.py`,
+  `components/chat/CheckpointsModal.jsx`.
+- [x] **Steering, follow-up queue & real cancellation.** Type while a turn is streaming to
+  queue a follow-up that auto-sends when the turn finishes; the approval pause/resume
+  covers interruption for that path. **Stop** now actually cancels the turn server-side —
+  a background task watches for the client disconnecting, sets a shared `cancel_event`,
+  and the harness/sandbox runner kill any in-flight subprocess (whole process **tree**, not
+  just the immediate child) instead of leaving it running to completion after the SSE
+  connection is gone. _Implemented in:_ `routers/chat.py` (`_watch_disconnect`),
+  `agent/harness.py` (`cancel_event`, `_cancelled`), `sandbox/runner.py`
+  (`_kill_process_tree`). (True token-level mid-run injection is still out of scope for the
+  SSE model.)
+- [x] **Live tool output streaming.** `run_shell`/`execute_python`/`execute_node` stream
+  stdout/stderr back as `tool_progress` SSE events while the command runs, instead of only
+  showing output once it finishes. _Implemented in:_ `agent/harness.py`
+  (`_execute_tool_streaming`), `agent/events.py` (`tool_progress`), `sandbox/runner.py`
+  (`on_output` callback threaded through all three runners), `ToolCallCard.jsx`.
 
 ## Tier 2 — Knowledge & memory
 
@@ -86,6 +104,11 @@ The things a user *feels* immediately; they make it a real agent, not "chat that
   Documents, Memory) and *admin* (MCP Servers, Tools, Users); admin routes gated by
   `require_admin`; admin tabs/links hidden for non-admins; Users management UI.
   _Implemented in:_ `auth/deps.require_admin`, `SettingsDrawer.jsx`, `UsersPanel.jsx`.
+- [x] **SSRF guard on `web_fetch`.** Blocks private/loopback/link-local addresses (incl.
+  the cloud metadata IP) by default, re-checked on every redirect hop so a public host
+  can't 302 its way to an internal one. File-only allowlist (`web_fetch` in `config.yml`)
+  for legitimate internal targets. _Implemented in:_ `agent/tools/web.py` (`_ssrf_guard`),
+  `config.py` (`get_web_fetch_config`).
 - [x] **Container sandbox (Podman/Docker).** `ContainerRunner` behind the `SandboxRunner`
   seam, targeting the **Docker-compatible CLI** (verified with **Podman** on Windows/WSL2,
   also works with Docker; portable to macOS/Linux). Per-execution ephemeral container with

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -184,6 +184,30 @@ misconfigured. Exit code 0 means the feature works against your account.
 > `max_sync_file_bytes` or set `sync_back: false` for execute-only workloads. Binary files are
 > synced as blobs; very large or numerous files are best kept out of the workspace.
 
+## Live output & cancellation
+
+All three runners stream partial stdout/stderr back to the UI as a command runs, instead
+of only showing output once the whole thing finishes — a `run_shell`/`execute_python`/
+`execute_node` tool card fills in live rather than staying blank until the call returns.
+Under the hood, `ctx.progress` (a callback the harness wires up per tool call) is passed
+through as `on_output` to `run_command`/`run_code`; each runner calls it with each new
+chunk as it's produced (a threaded `Popen` reader for `local`/`container`, the AWS event
+stream for `agentcore`), and the harness re-emits it as a `tool_progress` SSE event.
+
+Every execution also honors a per-turn `cancel_event`, threaded through the same path.
+Two things can set it: the command's own `timeout`, or the user clicking **Stop** (the
+chat router watches for the client disconnecting and sets the event so the harness's loop
+notices even though the SSE connection is already gone). Either way, the runner kills the
+**whole process tree**, not just the immediate child — plain `Popen.kill()` only kills the
+shell (`/bin/sh -c '...'`); anything that shell forked (the actual build/test command) was
+being orphaned and left running to completion regardless of the timeout. The local and
+container runners now start the child in its own process group/session
+(`start_new_session=True` on POSIX, `CREATE_NEW_PROCESS_GROUP` on Windows) and kill the
+group (`os.killpg` / `taskkill /T /F`) instead of just the one process. The `agentcore`
+runner has no way to interrupt a live remote invocation, so cancellation there just stops
+waiting on/reporting further output — the remote call still runs to completion in the
+session.
+
 ## Security properties
 
 - **Filesystem:** only the conversation workspace is mounted (`/work`); the rest of the

--- a/frontend/src/components/chat/ToolCallCard.jsx
+++ b/frontend/src/components/chat/ToolCallCard.jsx
@@ -11,7 +11,9 @@ const ICONS = {
 
 export default function ToolCallCard({ call }) {
   const [open, setOpen] = useState(false)
-  const running = call.content === null
+  // `running` is explicit (not just "content is null") because a still-running tool can
+  // now have partial content already — live progress streamed in via tool_progress.
+  const running = call.running ?? call.content === null
   const Icon = call.is_error ? AlertCircle : Terminal
 
   return (

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -315,14 +315,26 @@ export const useStore = create((set, get) => ({
               )
             : [
                 ...live.toolCalls,
-                { id: ev.id, name: ev.name, arguments: ev.arguments, content: null, is_error: false, artifacts: [] },
+                {
+                  id: ev.id, name: ev.name, arguments: ev.arguments,
+                  content: null, is_error: false, artifacts: [], running: true,
+                },
               ]
           break
         }
+        case 'tool_progress':
+          // Live partial output from a still-running tool (e.g. run_shell) — appended so
+          // the tool card shows progress instead of staying blank until it finishes.
+          // `running` stays true here (only tool_result clears it), so the spinner keeps
+          // showing while output streams in.
+          live.toolCalls = live.toolCalls.map((tc) =>
+            tc.id === ev.id ? { ...tc, content: (tc.content || '') + ev.content } : tc,
+          )
+          break
         case 'tool_result':
           live.toolCalls = live.toolCalls.map((tc) =>
             tc.id === ev.id
-              ? { ...tc, content: ev.content, is_error: ev.is_error, artifacts: ev.artifacts || [] }
+              ? { ...tc, content: ev.content, is_error: ev.is_error, artifacts: ev.artifacts || [], running: false }
               : tc,
           )
           live.status = ''


### PR DESCRIPTION
## Security fixes

- **Fixed a permission bypass in `spawn_subagent`**: it previously hardcoded `auto_approve=True` for its nested agent session, so approving a single sub-agent spawn silently unlocked every ask-tier tool (`run_shell`, `write_file`, etc.) inside it — regardless of the user's actual "Agent mode" setting. `PermissionGate` now takes an `interactive` flag; sub-agents run non-interactively, so `ask`-tier tools resolve to `deny` (not a hung pause, not a silent bypass) unless the parent turn was already in auto-approve mode.
- **Added an SSRF guard to `web_fetch`**: blocks requests to private/loopback/link-local addresses (including the cloud metadata IP, `169.254.169.254`) by default, re-validated on every redirect hop so a public host can't 302 its way to an internal one. Configurable allowlist for legitimate internal targets.
- Added test coverage for the permission gate's `allow`/`ask`/`deny` resolution (including the new `interactive` behavior), the workspace path-traversal guard, and the SSRF guard.

## Tool/harness effectiveness improvements

- **`grep_search`/`glob_search`** now skip vendor/build directories (`node_modules`, `.venv`, `.git`, etc.), and both tools plus `read_file` report when results were truncated instead of silently cutting off.
- **`read_file`** gained `offset`/`limit` pagination so files larger than the character cap can be read in full across multiple calls.
- **Live tool output streaming**: `run_shell`/`execute_python`/`execute_node` now stream stdout/stderr live via a new `tool_progress` SSE event (rendered incrementally in the tool card), instead of only showing output once the command finishes.
- **Fixed a process-tree-kill bug** found while building the above: a timeout or cancellation only killed the immediate shell process, orphaning any child process it spawned (e.g. an actual build/test tool) to keep running to completion regardless. The local and container sandbox runners now start children in their own process group/session and kill the whole tree.
- **Real turn cancellation**: clicking "Stop" now actually kills in-flight subprocesses and halts the turn server-side, via a disconnect-watching background task that sets a shared `cancel_event` consumed by the harness and sandbox runner. Previously, disconnecting just stopped the client from reading the stream while the backend kept working.
- **Concurrent sub-agents**: multiple `spawn_subagent` calls requested in the same round now run in parallel worker threads instead of sequentially. Required giving each sub-agent its own isolated DB session (SQLAlchemy sessions aren't thread-safe) and adding a per-workspace lock around git checkpoint commits to prevent corruption from concurrent writes.

## Testing

- New/expanded test coverage for: permission gate policy resolution, path traversal, SSRF guard, sub-agent permission inheritance, live tool-output streaming, cancellation (including the process-tree-kill fix), concurrent sub-agent execution, and checkpoint-lock safety under concurrent writers.
- Full backend suite (103 tests) and frontend build verified green throughout.