### PR TITLE
Custom assistants feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ models).
 - 🌐 **Opt-in live web search** — a per-prompt composer toggle exposes `web_search`
   backed by zero-config `ddgs` (or optional SearXNG), so the agent can discover current
   sources before fetching pages with `web_fetch`.
+- 🎭 **Custom assistants** — admins define named personas (name, avatar, description) on
+  top of any configured base model, with a custom **system prompt**, **starter prompt
+  suggestions**, an optional shared **knowledge base** (documents all users of the
+  assistant can search), and per-assistant **capability limits** (web search /
+  personal-document search / agent tools). Users pick an assistant on the new-chat screen;
+  the choice is pinned per conversation.
 - 🧠 **Cross-conversation memory** — durable facts recalled across chats.
 - 🖼️ **Multimodal** — attach images to messages for vision models.
 - 🔌 **MCP integration** — connect Model Context Protocol servers; their tools join
@@ -48,7 +54,7 @@ models).
   OpenAI-compatible server) for offline, self-hosted inference with no cloud API key; RAG
   embeddings can run locally too.
 - 🔐 **Auth & multi-user** — local accounts (or **Entra ID SSO**), `user`/`admin` roles,
-  per-user data isolation, an **admin panel** (users, MCP, tools, auth). See
+  per-user data isolation, an **admin panel** (assistants, users, MCP, tools, auth). See
   [docs/AUTH.md](docs/AUTH.md).
 - 💵 **Usage & cost accounting** — per-message token/cost in the UI, plus an admin
   **chargeback** view: usage by **month × user × department × model**, CSV export for

--- a/backend/app/agent/harness.py
+++ b/backend/app/agent/harness.py
@@ -78,6 +78,7 @@ class AgentSession:
             db=db,
             runner=get_runner(),
             user_id=getattr(conversation, "user_id", None),
+            assistant_id=getattr(conversation, "assistant_id", None),
             auto_approve=gate.auto_approve,
             cancel_event=cancel_event,
         )

--- a/backend/app/agent/tools/base.py
+++ b/backend/app/agent/tools/base.py
@@ -25,6 +25,10 @@ class ToolContext:
     db: Session
     runner: SandboxRunner
     user_id: str | None = None
+    #: the conversation's pinned assistant, if any; widens search_documents to that
+    #: assistant's shared knowledge base. Trusted because it comes from the conversation
+    #: row, which is only ever set from a visibility-checked assistant (routers/chat.py).
+    assistant_id: str | None = None
     #: whether the *current turn* is running with ask-tier tools auto-approved. Tools that
     #: delegate to a nested agent (e.g. spawn_subagent) must respect this rather than
     #: hardcoding their own approval policy — see PermissionGate(interactive=...).

--- a/backend/app/agent/tools/docs.py
+++ b/backend/app/agent/tools/docs.py
@@ -42,7 +42,7 @@ class SearchDocuments(Tool):
         hits = search_chunks(
             ctx.db, query, top_k=top_k,
             conversation_id=ctx.conversation_id, user_id=ctx.user_id,
-            document_ids=document_ids,
+            document_ids=document_ids, assistant_id=ctx.assistant_id,
         )
         if not hits:
             return ToolResult(content="No relevant passages found in uploaded documents.")

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -41,8 +41,12 @@ def get_db() -> Iterator[Session]:
 # tool like Alembic is the Tier-3 upgrade; this keeps dev data intact in the meantime.)
 _ADDED_COLUMNS: dict[str, dict[str, str]] = {
     "messages": {"attachments": "JSON", "usage": "JSON"},
-    "documents": {"conversation_id": "VARCHAR(32)", "user_id": "VARCHAR(32)"},
-    "conversations": {"user_id": "VARCHAR(32)"},
+    "documents": {
+        "conversation_id": "VARCHAR(32)",
+        "user_id": "VARCHAR(32)",
+        "assistant_id": "VARCHAR(32)",
+    },
+    "conversations": {"user_id": "VARCHAR(32)", "assistant_id": "VARCHAR(32)"},
     "memories": {"user_id": "VARCHAR(32)"},
     "users": {"department": "VARCHAR(200)"},
     "mcp_servers": {"headers": "JSON", "auth_token": "VARCHAR(2000)"},

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.observability import setup_observability
 from app.routers import (
     admin_config,
     api_keys,
+    assistants,
     attachments,
     auth,
     budgets,
@@ -119,9 +120,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-for r in (auth, chat, conversations, providers, settings, documents, mcp, tools, files,
-          memories, checkpoints, attachments, usage, admin_config, api_keys, gateway,
-          budgets):
+for r in (auth, chat, conversations, providers, settings, documents, assistants, mcp,
+          tools, files, memories, checkpoints, attachments, usage, admin_config, api_keys,
+          gateway, budgets):
     app.include_router(r.router)
 
 # Structured request logging (always) + OpenTelemetry tracing (if configured).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -63,11 +63,45 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
 
 
+class Assistant(Base):
+    """An admin-curated persona: a base model + system prompt + optional knowledge base.
+
+    Users pick an assistant when starting a chat; the choice is pinned per conversation.
+    ``profile``/``model`` are nullable — null falls back to the chatting user's settings.
+    ``capabilities`` holds hard limits (``web_search`` / ``document_search`` / ``tools``);
+    a missing key means allowed. ``created_by`` + ``visibility`` are FK-free groundwork for
+    future user-created assistants (writes are admin-only today).
+    """
+
+    __tablename__ = "assistants"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
+    name: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # A "data:image/..." data URL or a short emoji; null → the UI renders initials.
+    avatar: Mapped[str | None] = mapped_column(Text, nullable=True)
+    profile: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    model: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    system_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Generation-param overrides (temperature, max_tokens...); no editor UI yet.
+    params: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    prompt_suggestions: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    capabilities: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    visibility: Mapped[str] = mapped_column(String(20), default="public")  # public | private
+    created_by: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=_now, onupdate=_now)
+
+
 class Conversation(Base):
     __tablename__ = "conversations"
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
     user_id: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
+    # Assistant pinned at creation; dangles (no FK) after assistant deletion so the
+    # conversation keeps running on its snapshotted profile/model/system_prompt.
+    assistant_id: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
     title: Mapped[str] = mapped_column(String(300), default="New chat")
     profile: Mapped[str | None] = mapped_column(String(100), nullable=True)
     model: Mapped[str | None] = mapped_column(String(200), nullable=True)
@@ -112,6 +146,9 @@ class Document(Base):
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
     user_id: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
+    # Set for assistant knowledge-base docs, which are deployment-owned (user_id NULL):
+    # they survive creator deletion and never appear in personal document listings.
+    assistant_id: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
     filename: Mapped[str] = mapped_column(String(500))
     # null = global knowledge base; otherwise scoped to one conversation.
     conversation_id: Mapped[str | None] = mapped_column(String(32), nullable=True, index=True)

--- a/backend/app/rag/ingest.py
+++ b/backend/app/rag/ingest.py
@@ -19,7 +19,13 @@ def _payload(document, chunk) -> dict:
     """Qdrant payload for a chunk (scope keys omitted when empty so IsEmpty matches)."""
     from app.rag.retrieve import build_chunk_payload
 
-    return build_chunk_payload(chunk, document.filename, document.conversation_id, document.user_id)
+    return build_chunk_payload(
+        chunk,
+        document.filename,
+        document.conversation_id,
+        document.user_id,
+        document.assistant_id,
+    )
 TEXT_EXTS = {".txt", ".md", ".markdown", ".py", ".js", ".ts", ".json", ".csv", ".html", ".xml", ".yaml", ".yml"}
 
 

--- a/backend/app/rag/retrieve.py
+++ b/backend/app/rag/retrieve.py
@@ -23,13 +23,14 @@ CANDIDATE_MULTIPLIER = 4  # fetch this many * top_k before reranking
 def search_chunks(
     db: Session, query: str, top_k: int = 5,
     conversation_id: str | None = None, user_id: str | None = None,
-    document_ids: list[str] | None = None,
+    document_ids: list[str] | None = None, assistant_id: str | None = None,
 ) -> list[dict]:  # noqa: ARG001
     """Return [{score, text, filename, ordinal, document_id}] for the best matches.
 
     Restricted to ``user_id``'s documents (+ legacy unowned), and if ``conversation_id`` is
     given, to global documents plus that conversation's scoped documents. ``document_ids``
-    can narrow retrieval further for explicit user references.
+    can narrow retrieval further for explicit user references. ``assistant_id`` widens the
+    scope to that assistant's shared knowledge base — pass only visibility-checked ids.
     """
     dense = embed_query(query)
     sparse = sparse_embed(query)
@@ -38,6 +39,7 @@ def search_chunks(
         hits = get_vector_store().search(
             dense, sparse, limit=candidate_n,
             conversation_id=conversation_id, user_id=user_id, document_ids=document_ids,
+            assistant_id=assistant_id,
         )
     except Exception as e:  # noqa: BLE001
         logger.warning("Vector search failed: %s", e)
@@ -63,7 +65,13 @@ def search_chunks(
 def reindex_all(db: Session) -> int:
     """Rebuild the vector index from SQLite DocChunks. Returns chunks indexed."""
     rows = (
-        db.query(DocChunk, Document.filename, Document.conversation_id, Document.user_id)
+        db.query(
+            DocChunk,
+            Document.filename,
+            Document.conversation_id,
+            Document.user_id,
+            Document.assistant_id,
+        )
         .join(Document, Document.id == DocChunk.document_id)
         .filter(DocChunk.embedding.isnot(None))
         .all()
@@ -79,15 +87,15 @@ def reindex_all(db: Session) -> int:
                 "id": chunk.id,
                 "dense": chunk.embedding,
                 "sparse": sparse_embed(chunk.text),
-                "payload": build_chunk_payload(chunk, filename, conv_id, uid),
+                "payload": build_chunk_payload(chunk, filename, conv_id, uid, aid),
             }
-            for chunk, filename, conv_id, uid in rows
+            for chunk, filename, conv_id, uid, aid in rows
         ]
     )
     return len(rows)
 
 
-def build_chunk_payload(chunk, filename, conversation_id, user_id) -> dict:
+def build_chunk_payload(chunk, filename, conversation_id, user_id, assistant_id=None) -> dict:
     """Qdrant payload for a chunk. Omit empty scope keys so IsEmpty filters match."""
     p = {
         "chunk_id": chunk.id,
@@ -100,4 +108,6 @@ def build_chunk_payload(chunk, filename, conversation_id, user_id) -> dict:
         p["conversation_id"] = conversation_id
     if user_id:
         p["user_id"] = user_id
+    if assistant_id:
+        p["assistant_id"] = assistant_id
     return p

--- a/backend/app/rag/store.py
+++ b/backend/app/rag/store.py
@@ -41,12 +41,14 @@ class VectorStore(ABC):
     def search(
         self, dense: list[float], sparse: dict, limit: int,
         conversation_id: str | None = None, user_id: str | None = None,
-        document_ids: list[str] | None = None,
+        document_ids: list[str] | None = None, assistant_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Hybrid search; returns up to ``limit`` fused [{score, payload}].
 
         Restricted to the given ``user_id`` (plus legacy unowned) and, if
         ``conversation_id`` is given, to global docs plus that conversation's scoped docs.
+        ``assistant_id`` additionally admits that assistant's shared knowledge-base chunks;
+        callers must pass only a visibility-checked assistant id (see routers/chat.py).
         """
 
     @abstractmethod
@@ -154,14 +156,30 @@ class QdrantVectorStore(VectorStore):
         user_id: str | None,
         conversation_id: str | None,
         document_ids: list[str] | None = None,
+        assistant_id: str | None = None,
     ):
         """Restrict to user/conversation scope and optionally specific document ids."""
         from qdrant_client.models import FieldCondition, Filter, IsEmptyCondition, MatchValue, PayloadField
 
         must = []
-        if user_id:
+        if user_id and assistant_id:
+            # Personal KB plus the assistant's shared KB. Assistant chunks carry an
+            # assistant_id payload and no user_id, so the two branches never overlap;
+            # assistant_id is trusted here only because callers resolve it through a
+            # visibility check (never raw request input).
+            must.append(
+                Filter(
+                    should=[
+                        FieldCondition(key="user_id", match=MatchValue(value=user_id)),
+                        FieldCondition(key="assistant_id", match=MatchValue(value=assistant_id)),
+                    ]
+                )
+            )
+        elif user_id:
             # Strict: only the owner's chunks (no legacy/unowned allowance) — privacy.
             must.append(FieldCondition(key="user_id", match=MatchValue(value=user_id)))
+        elif assistant_id:
+            must.append(FieldCondition(key="assistant_id", match=MatchValue(value=assistant_id)))
         if conversation_id:
             must.append(
                 Filter(
@@ -188,11 +206,11 @@ class QdrantVectorStore(VectorStore):
     def search(
         self, dense: list[float], sparse: dict, limit: int,
         conversation_id: str | None = None, user_id: str | None = None,
-        document_ids: list[str] | None = None,
+        document_ids: list[str] | None = None, assistant_id: str | None = None,
     ) -> list[dict[str, Any]]:
         from qdrant_client.models import SparseVector
 
-        qfilter = self._scope_filter(user_id, conversation_id, document_ids)
+        qfilter = self._scope_filter(user_id, conversation_id, document_ids, assistant_id)
         with self._lock:
             if not self._client.collection_exists(self.collection):
                 return []

--- a/backend/app/routers/assistants.py
+++ b/backend/app/routers/assistants.py
@@ -1,0 +1,196 @@
+"""Custom assistants: admin-curated personas (base model + system prompt + knowledge base).
+
+Reads are open to any authenticated user (filtered to active, public-or-own assistants);
+writes are admin-only for now — ``created_by`` + ``visibility`` already support opening
+creation up to users later. Knowledge-base documents live in the ``documents`` table with
+``assistant_id`` set and ``user_id`` NULL (deployment-owned): they survive creator deletion
+and never appear in personal document listings.
+"""
+from __future__ import annotations
+
+import shutil
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, UploadFile
+from sqlalchemy.orm import Session
+
+from app.auth.deps import get_current_user, require_admin
+from app.config import UPLOADS_DIR
+from app.database import get_db
+from app.models import Assistant, Document, User
+from app.routers.documents import DocumentOut, _ingest_job
+from app.schemas import AssistantCreate, AssistantOut, AssistantUpdate
+
+router = APIRouter(prefix="/api/assistants", tags=["assistants"])
+
+
+def _visible(db: Session, assistant_id: str, user: User) -> Assistant:
+    a = db.get(Assistant, assistant_id)
+    if not a or (a.visibility != "public" and a.created_by != user.id and user.role != "admin"):
+        raise HTTPException(404, "Assistant not found")
+    return a
+
+
+def _doc_counts(db: Session, assistant_ids: list[str]) -> dict[str, int]:
+    if not assistant_ids:
+        return {}
+    from sqlalchemy import func
+
+    rows = (
+        db.query(Document.assistant_id, func.count(Document.id))
+        .filter(Document.assistant_id.in_(assistant_ids), Document.status == "ready")
+        .group_by(Document.assistant_id)
+        .all()
+    )
+    return dict(rows)
+
+
+def _out(a: Assistant, n_documents: int) -> AssistantOut:
+    out = AssistantOut.model_validate(a)
+    out.n_documents = n_documents
+    return out
+
+
+@router.get("", response_model=list[AssistantOut])
+def list_assistants(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    q = db.query(Assistant).filter(Assistant.is_active.is_(True))
+    if user.role != "admin":
+        # Admins see all assistants (they manage them); users see public + their own.
+        q = q.filter(
+            (Assistant.visibility == "public") | (Assistant.created_by == user.id)
+        )
+    rows = q.order_by(Assistant.created_at).all()
+    counts = _doc_counts(db, [a.id for a in rows])
+    return [_out(a, counts.get(a.id, 0)) for a in rows]
+
+
+@router.post("", response_model=AssistantOut)
+def create_assistant(
+    body: AssistantCreate, db: Session = Depends(get_db), user: User = Depends(require_admin)
+):
+    a = Assistant(**body.model_dump(), created_by=user.id)
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return _out(a, 0)
+
+
+@router.get("/{assistant_id}", response_model=AssistantOut)
+def get_assistant(
+    assistant_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    a = _visible(db, assistant_id, user)
+    return _out(a, _doc_counts(db, [a.id]).get(a.id, 0))
+
+
+@router.patch("/{assistant_id}", response_model=AssistantOut)
+def update_assistant(
+    assistant_id: str,
+    body: AssistantUpdate,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    a = db.get(Assistant, assistant_id)
+    if not a:
+        raise HTTPException(404, "Assistant not found")
+    for key, value in body.model_dump(exclude_unset=True).items():
+        setattr(a, key, value)
+    db.commit()
+    db.refresh(a)
+    return _out(a, _doc_counts(db, [a.id]).get(a.id, 0))
+
+
+@router.delete("/{assistant_id}")
+def delete_assistant(
+    assistant_id: str, db: Session = Depends(get_db), _: User = Depends(require_admin)
+):
+    a = db.get(Assistant, assistant_id)
+    if not a:
+        raise HTTPException(404, "Assistant not found")
+    # Cascade the knowledge base: rows (chunks cascade via ORM), upload files, vectors.
+    docs = db.query(Document).filter(Document.assistant_id == assistant_id).all()
+    doc_ids = [d.id for d in docs]
+    for doc in docs:
+        db.delete(doc)
+    db.delete(a)
+    db.commit()
+    for doc_id in doc_ids:
+        for p in UPLOADS_DIR.glob(f"{doc_id}_*"):
+            p.unlink(missing_ok=True)
+        try:
+            from app.rag.store import get_vector_store
+
+            get_vector_store().delete_by_document(doc_id)
+        except Exception:  # noqa: BLE001
+            pass
+    # Conversations keep their dangling assistant_id and degrade to the snapshot.
+    return {"deleted": assistant_id, "documents_deleted": len(doc_ids)}
+
+
+# -- knowledge base ----------------------------------------------------------
+@router.get("/{assistant_id}/documents", response_model=list[DocumentOut])
+def list_assistant_documents(
+    assistant_id: str, db: Session = Depends(get_db), _: User = Depends(require_admin)
+):
+    if not db.get(Assistant, assistant_id):
+        raise HTTPException(404, "Assistant not found")
+    return (
+        db.query(Document)
+        .filter(Document.assistant_id == assistant_id)
+        .order_by(Document.created_at.desc())
+        .all()
+    )
+
+
+@router.post("/{assistant_id}/documents", response_model=DocumentOut)
+async def upload_assistant_document(
+    assistant_id: str,
+    background: BackgroundTasks,
+    file: UploadFile,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    if not db.get(Assistant, assistant_id):
+        raise HTTPException(404, "Assistant not found")
+    doc = Document(
+        filename=file.filename or "upload",
+        mime=file.content_type,
+        status="pending",
+        assistant_id=assistant_id,
+        user_id=None,  # deployment-owned; see module docstring
+    )
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+
+    dest = UPLOADS_DIR / f"{doc.id}_{doc.filename}"
+    with open(dest, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+    doc.size_bytes = dest.stat().st_size
+    db.commit()
+    db.refresh(doc)
+
+    background.add_task(_ingest_job, doc.id, str(dest))
+    return doc
+
+
+@router.delete("/{assistant_id}/documents/{document_id}")
+def delete_assistant_document(
+    assistant_id: str,
+    document_id: str,
+    db: Session = Depends(get_db),
+    _: User = Depends(require_admin),
+):
+    doc = db.get(Document, document_id)
+    if not doc or doc.assistant_id != assistant_id:
+        raise HTTPException(404, "Document not found")
+    db.delete(doc)
+    db.commit()
+    for p in UPLOADS_DIR.glob(f"{document_id}_*"):
+        p.unlink(missing_ok=True)
+    try:
+        from app.rag.store import get_vector_store
+
+        get_vector_store().delete_by_document(document_id)
+    except Exception:  # noqa: BLE001
+        pass
+    return {"deleted": document_id}

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -19,7 +19,7 @@ from app.agent.permissions import PermissionGate
 from app.agent.registry import REGISTRY
 from app.auth.deps import get_current_user
 from app.database import get_db
-from app.models import Conversation, DocChunk, Document, Message, PendingApproval, User
+from app.models import Assistant, Conversation, DocChunk, Document, Message, PendingApproval, User
 from app.providers.registry import build_provider
 from app.runtime_settings import generation_params, get_settings
 from app.schemas import ApproveRequest, ChatRequest
@@ -38,6 +38,32 @@ answering factual questions that may be answered by the user's uploaded document
 the answer in the retrieved passages and cite the source numbers returned by the tool. If
 the search finds nothing relevant, say that clearly instead of answering from memory.
 """
+
+ASSISTANT_KB_PROMPT = """
+
+You have a curated knowledge base attached to this assistant. Use the `search_documents`
+tool before answering factual questions in your domain — it searches your knowledge base
+(and the user's own documents). Ground answers in the retrieved passages and cite the
+source numbers returned by the tool. If the search finds nothing relevant, say so clearly
+instead of answering from memory.
+"""
+
+
+def _resolve_assistant(db: Session, assistant_id: str | None, user: User) -> Assistant | None:
+    """Load an assistant iff it exists, is active, and is visible to this user.
+
+    This visibility check is the security boundary for the widened retrieval scope
+    (assistant KB chunks are shared across users) — never pass an unresolved id further.
+    Returns None on any failure so conversations degrade to their snapshotted config.
+    """
+    if not assistant_id:
+        return None
+    a = db.get(Assistant, assistant_id)
+    if not a or not a.is_active:
+        return None
+    if a.visibility != "public" and a.created_by != user.id:
+        return None
+    return a
 
 
 def _build_history(conversation: Conversation, system_prompt: str) -> list[dict]:
@@ -291,14 +317,6 @@ async def chat(
     req: ChatRequest, request: Request, db: Session = Depends(get_db), user: User = Depends(get_current_user)
 ):
     settings = get_settings(db, user.id)
-    profile = req.profile or settings["active_profile"]
-    model = req.model or settings.get("model")
-
-    # Budget gate: refuse a priced model once this user (or their department) is over their
-    # monthly cap. Runs before any message is persisted so a blocked turn writes nothing.
-    from app.budgets import enforce_budget
-
-    enforce_budget(db, user, model)
 
     conversation: Conversation | None = None
     if req.conversation_id:
@@ -306,20 +324,45 @@ async def chat(
         # Conversations are private to their creator (admins included).
         if conversation and conversation.user_id != user.id:
             raise HTTPException(404, "Conversation not found")
+
+    # The pinned assistant wins on existing conversations; req.assistant_id only applies
+    # when creating a new one (prevents retrieval-scope spoofing via the request body).
+    assistant = _resolve_assistant(
+        db, conversation.assistant_id if conversation else req.assistant_id, user
+    )
+
+    profile = req.profile or (assistant.profile if assistant else None) or settings["active_profile"]
+    model = req.model or (assistant.model if assistant else None) or settings.get("model")
+
+    # Budget gate: refuse a priced model once this user (or their department) is over their
+    # monthly cap. Runs before any message is persisted so a blocked turn writes nothing.
+    from app.budgets import enforce_budget
+
+    enforce_budget(db, user, model)
+
     if conversation is None:
         conversation = Conversation(
             title=req.message[:60] or ("Document chat" if req.document_ids else "New chat"),
             profile=profile,
             model=model,
-            system_prompt=settings["system_prompt"],
-            params=generation_params(settings),
+            # Snapshot the assistant's config so the thread degrades gracefully if the
+            # assistant is later deleted or hidden.
+            system_prompt=(assistant.system_prompt if assistant else None)
+            or settings["system_prompt"],
+            params={**generation_params(settings), **((assistant.params if assistant else None) or {})},
+            assistant_id=assistant.id if assistant else None,
             user_id=user.id,
         )
         db.add(conversation)
         db.commit()
         db.refresh(conversation)
 
-    system_prompt = conversation.system_prompt or settings["system_prompt"]
+    # Live assistant prompt first (admin edits propagate), then the snapshot, then settings.
+    system_prompt = (
+        (assistant.system_prompt if assistant else None)
+        or conversation.system_prompt
+        or settings["system_prompt"]
+    )
     # Inject relevant long-term memories (this user's, cross-conversation) into the prompt.
     from app.memory import memory_preamble
 
@@ -333,7 +376,21 @@ async def chat(
     else:
         referenced_docs = _resolve_document_refs(db, user, conversation, req.document_ids)
 
-    if req.document_search:
+    # Capability limits are hard server-side rules; the UI mirrors them as disabled
+    # toggles. A missing key means allowed.
+    caps = (assistant.capabilities or {}) if assistant else {}
+    web_search_allowed = req.web_search and caps.get("web_search", True)
+    document_search_requested = req.document_search and caps.get("document_search", True)
+    assistant_has_kb = assistant is not None and (
+        db.query(Document.id)
+        .filter(Document.assistant_id == assistant.id, Document.status == "ready")
+        .first()
+        is not None
+    )
+
+    if assistant_has_kb:
+        system_prompt += ASSISTANT_KB_PROMPT
+    elif document_search_requested:
         system_prompt += DOCUMENT_SEARCH_PROMPT
     if referenced_docs:
         system_prompt += _referenced_document_context(
@@ -364,6 +421,7 @@ async def chat(
     history = _build_history(conversation, system_prompt)
     params = {
         **generation_params(settings),
+        **((assistant.params if assistant else None) or {}),
         "max_tool_rounds": (conversation.params or {}).get(
             "max_tool_rounds", settings["max_tool_rounds"]
         ),
@@ -392,10 +450,15 @@ async def chat(
 
             gate = PermissionGate(db, REGISTRY, auto_approve=req.auto_approve)
             enabled_tools = gate.enabled_names()
-            if not req.web_search:
+            if not web_search_allowed:
                 enabled_tools.discard("web_search")
-            if not (req.document_search or referenced_docs):
+            # The assistant's knowledge base force-enables document search — it is the
+            # point of attaching one.
+            if not (document_search_requested or referenced_docs or assistant_has_kb):
                 enabled_tools.discard("search_documents")
+            if not caps.get("tools", True):
+                # Chat + knowledge only: no code execution, shell, files, or MCP tools.
+                enabled_tools &= {"web_search", "search_documents"}
             session = AgentSession(
                 db, conversation, provider, REGISTRY, gate, params, profile, model,
                 allowed_tools=enabled_tools,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -28,6 +28,7 @@ class ConversationOut(BaseModel):
     title: str
     profile: str | None = None
     model: str | None = None
+    assistant_id: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -55,12 +56,122 @@ class ConversationUpdate(BaseModel):
     params: dict | None = None
 
 
+# -- assistants --------------------------------------------------------------
+_AVATAR_MAX_CHARS = 200_000  # ~150 KB base64 image; client resizes before upload
+
+
+def _validate_visibility(v: str | None) -> str | None:
+    if v is not None and v not in ("public", "private"):
+        raise ValueError("visibility must be one of: public, private")
+    return v
+
+
+def _validate_avatar(v: str | None) -> str | None:
+    if not v:
+        return None
+    if len(v) > _AVATAR_MAX_CHARS:
+        raise ValueError("avatar image too large; resize before upload")
+    if not v.startswith("data:image/") and len(v) > 16:
+        raise ValueError("avatar must be a data:image/ URL or a short emoji")
+    return v
+
+
+class AssistantBase(BaseModel):
+    name: str
+    description: str | None = None
+    # Either a "data:image/..." data URL or a short emoji string.
+    avatar: str | None = None
+    # Base model; null falls back to the chatting user's settings.
+    profile: str | None = None
+    model: str | None = None
+    system_prompt: str | None = None
+    # Generation-param overrides (no editor UI yet).
+    params: dict | None = None
+    prompt_suggestions: list[str] = []
+    # Hard capability limits: {"web_search", "document_search", "tools"} -> bool.
+    capabilities: dict[str, bool] = {}
+    visibility: str = "public"  # public | private
+
+    @field_validator("visibility")
+    @classmethod
+    def _check_visibility(cls, v: str) -> str:
+        return _validate_visibility(v)
+
+    @field_validator("avatar")
+    @classmethod
+    def _check_avatar(cls, v: str | None) -> str | None:
+        return _validate_avatar(v)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name is required")
+        return v
+
+    # JSON columns come back as NULL from the ORM; coerce to the typed defaults.
+    @field_validator("prompt_suggestions", mode="before")
+    @classmethod
+    def _default_suggestions(cls, v):
+        return v if v is not None else []
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def _default_capabilities(cls, v):
+        return v if v is not None else {}
+
+
+class AssistantCreate(AssistantBase):
+    pass
+
+
+class AssistantUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    avatar: str | None = None
+    profile: str | None = None
+    model: str | None = None
+    system_prompt: str | None = None
+    params: dict | None = None
+    prompt_suggestions: list[str] | None = None
+    capabilities: dict[str, bool] | None = None
+    visibility: str | None = None
+    is_active: bool | None = None
+
+    @field_validator("visibility")
+    @classmethod
+    def _check_visibility(cls, v: str | None) -> str | None:
+        return _validate_visibility(v)
+
+    @field_validator("avatar")
+    @classmethod
+    def _check_avatar(cls, v: str | None) -> str | None:
+        return _validate_avatar(v)
+
+
+class AssistantOut(AssistantBase):
+    id: str
+    created_by: str | None = None
+    is_active: bool = True
+    # Ready knowledge-base document count, computed in the router.
+    n_documents: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 # -- chat ------------------------------------------------------------------
 class ChatRequest(BaseModel):
     conversation_id: str | None = None
     message: str = ""
     profile: str | None = None
     model: str | None = None
+    # Assistant persona for a NEW conversation; ignored on existing conversations
+    # (the conversation's pinned assistant wins).
+    assistant_id: str | None = None
     # When true, tools whose policy is "ask" are auto-approved for this turn.
     auto_approve: bool = True
     # When true, advertise web_search to the model for this turn.

--- a/backend/tests/test_assistants.py
+++ b/backend/tests/test_assistants.py
@@ -1,0 +1,342 @@
+"""Custom assistants: CRUD, visibility, chat integration, and KB retrieval scoping."""
+import pytest
+
+
+def _make_assistant(client, **overrides):
+    body = {
+        "name": "IT Assistant",
+        "description": "Helps with IT questions",
+        "system_prompt": "You are Bridget, an IT architecture assistant.",
+        "prompt_suggestions": ["Who are you?"],
+        "capabilities": {"web_search": False},
+        "visibility": "public",
+        **overrides,
+    }
+    r = client.post("/api/assistants", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_assistant_crud_roundtrip(client):
+    a = _make_assistant(client)
+    assert a["name"] == "IT Assistant"
+    assert a["capabilities"] == {"web_search": False}
+    assert a["created_by"] == "local"
+    assert a["n_documents"] == 0
+
+    listed = client.get("/api/assistants").json()
+    assert any(x["id"] == a["id"] for x in listed)
+
+    # Partial PATCH only touches the provided fields.
+    r = client.patch(f"/api/assistants/{a['id']}", json={"description": "Updated"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["description"] == "Updated"
+    assert body["system_prompt"] == "You are Bridget, an IT architecture assistant."
+
+    assert client.delete(f"/api/assistants/{a['id']}").status_code == 200
+    assert client.get(f"/api/assistants/{a['id']}").status_code == 404
+
+
+def test_assistant_validators(client):
+    r = client.post("/api/assistants", json={"name": "x", "visibility": "sneaky"})
+    assert r.status_code == 422
+
+    r = client.post("/api/assistants", json={"name": "x", "avatar": "not-an-image-" * 3})
+    assert r.status_code == 422  # long non-data-URL avatar rejected
+
+    r = client.post("/api/assistants", json={"name": "   "})
+    assert r.status_code == 422
+
+    # Emoji and data-URL avatars are accepted.
+    a = _make_assistant(client, name="Emoji", avatar="🤖")
+    client.delete(f"/api/assistants/{a['id']}")
+    a = _make_assistant(client, name="Img", avatar="data:image/png;base64,AAAA")
+    client.delete(f"/api/assistants/{a['id']}")
+
+
+def test_require_admin_gates_writes():
+    from fastapi import HTTPException
+
+    from app.auth.deps import require_admin
+    from app.models import User
+
+    non_admin = User(id="u-plain", username="bob", role="user")
+    with pytest.raises(HTTPException) as ei:
+        require_admin(non_admin)
+    assert ei.value.status_code == 403
+
+
+def test_visibility_filtering(client, db):
+    from app.models import User
+    from app.routers.assistants import list_assistants
+
+    pub = _make_assistant(client, name="Public A")
+    priv = _make_assistant(client, name="Private A", visibility="private")
+
+    viewer = User(id="u-viewer", username="viewer", role="user")
+    names = {a.name for a in list_assistants(db=db, user=viewer)}
+    assert "Public A" in names
+    assert "Private A" not in names  # someone else's private assistant is hidden
+
+    # The admin creator still sees both.
+    admin = User(id="local", username="local", role="admin")
+    names = {a.name for a in list_assistants(db=db, user=admin)}
+    assert {"Public A", "Private A"} <= names
+
+    client.delete(f"/api/assistants/{pub['id']}")
+    client.delete(f"/api/assistants/{priv['id']}")
+
+
+class CaptureProvider:
+    model = "capture"
+    supports_tools = True
+
+    def __init__(self, log):
+        self.log = log
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        from app.providers.base import StreamDelta
+
+        self.log.append({"messages": messages, "tools": {t.name for t in tools}, "params": params})
+        yield StreamDelta(type="text", text="ok")
+        yield StreamDelta(type="done", stop_reason="stop")
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    import app.routers.chat as chat_router
+
+    log = []
+    monkeypatch.setattr(chat_router, "build_provider", lambda profile, model=None: CaptureProvider(log))
+    monkeypatch.setattr(chat_router, "_build_fallback", lambda active_profile: None)
+    return log
+
+
+def test_chat_pins_and_snapshots_assistant(client, db, capture):
+    from app.models import Conversation
+
+    a = _make_assistant(client, name="Pinned", profile="test", model="test-model")
+
+    r = client.post("/api/chat", json={"message": "hello", "assistant_id": a["id"]})
+    assert r.status_code == 200
+    assert capture, "provider was not called"
+
+    # Assistant persona is the system prompt.
+    assert capture[-1]["messages"][0]["content"].startswith(
+        "You are Bridget, an IT architecture assistant."
+    )
+    # web_search capability False -> tool stripped even though default tools include it.
+    assert "web_search" not in capture[-1]["tools"]
+
+    conv = (
+        db.query(Conversation).filter(Conversation.assistant_id == a["id"]).first()
+    )
+    assert conv is not None
+    assert conv.profile == "test" and conv.model == "test-model"
+    assert conv.system_prompt.startswith("You are Bridget")
+
+    # req.assistant_id on an existing conversation is ignored (pin wins).
+    b = _make_assistant(client, name="Other", system_prompt="You are someone else.")
+    r = client.post(
+        "/api/chat",
+        json={"message": "again", "conversation_id": conv.id, "assistant_id": b["id"]},
+    )
+    assert r.status_code == 200
+    assert capture[-1]["messages"][0]["content"].startswith("You are Bridget")
+
+    client.delete(f"/api/assistants/{a['id']}")
+    client.delete(f"/api/assistants/{b['id']}")
+    client.delete(f"/api/conversations/{conv.id}")
+
+
+def test_chat_capability_narrowing_tools_off(client, capture):
+    a = _make_assistant(
+        client, name="QA only", capabilities={"web_search": True, "tools": False}
+    )
+    r = client.post(
+        "/api/chat", json={"message": "hi", "assistant_id": a["id"], "web_search": True}
+    )
+    assert r.status_code == 200
+    # tools:false leaves at most web_search + search_documents.
+    assert capture[-1]["tools"] <= {"web_search", "search_documents"}
+    assert "web_search" in capture[-1]["tools"]  # allowed by capability + requested
+    client.delete(f"/api/assistants/{a['id']}")
+
+
+def test_chat_assistant_kb_forces_document_search(client, db, capture):
+    from app.models import Document
+
+    a = _make_assistant(client, name="KB bot")
+    doc = Document(
+        filename="kb.md", status="ready", n_chunks=1, assistant_id=a["id"], user_id=None
+    )
+    db.add(doc)
+    db.commit()
+
+    r = client.post("/api/chat", json={"message": "what do the docs say?", "assistant_id": a["id"]})
+    assert r.status_code == 200
+    assert "search_documents" in capture[-1]["tools"]
+    assert "curated knowledge base" in capture[-1]["messages"][0]["content"]
+
+    client.delete(f"/api/assistants/{a['id']}")
+
+
+def test_chat_deleted_assistant_degrades_to_snapshot(client, db, capture):
+    from app.models import Conversation
+
+    a = _make_assistant(client, name="Ephemeral")
+    r = client.post("/api/chat", json={"message": "hello", "assistant_id": a["id"]})
+    assert r.status_code == 200
+    conv = db.query(Conversation).filter(Conversation.assistant_id == a["id"]).first()
+    assert conv is not None
+
+    client.delete(f"/api/assistants/{a['id']}")
+
+    r = client.post("/api/chat", json={"message": "still there?", "conversation_id": conv.id})
+    assert r.status_code == 200
+    # Runs on the snapshotted system prompt (live assistant is gone).
+    assert capture[-1]["messages"][0]["content"].startswith("You are Bridget")
+    client.delete(f"/api/conversations/{conv.id}")
+
+
+def test_chat_resolves_assistant_model_before_budget(client, capture, monkeypatch):
+    import app.budgets as budgets_mod
+
+    seen_models = []
+    monkeypatch.setattr(
+        budgets_mod, "enforce_budget", lambda db, user, model: seen_models.append(model)
+    )
+    a = _make_assistant(client, name="Priced", profile="test", model="expensive-model")
+    r = client.post("/api/chat", json={"message": "hi", "assistant_id": a["id"]})
+    assert r.status_code == 200
+    assert seen_models[-1] == "expensive-model"
+    client.delete(f"/api/assistants/{a['id']}")
+
+
+# -- retrieval scoping --------------------------------------------------------
+
+def test_scope_filter_assistant_branches():
+    """The Qdrant filter must OR user + assistant scopes, and keep strict user scope
+    when no assistant is in play."""
+    from app.rag.store import QdrantVectorStore
+
+    # _scope_filter doesn't touch self, so call it unbound (no embedded store needed).
+    f = QdrantVectorStore._scope_filter(None, "u1", None, assistant_id="a1")
+    outer = f.must[0]
+    kinds = {(c.key, c.match.value) for c in outer.should}
+    assert kinds == {("user_id", "u1"), ("assistant_id", "a1")}
+
+    f = QdrantVectorStore._scope_filter(None, "u1", None)
+    assert f.must[0].key == "user_id" and f.must[0].match.value == "u1"
+    # No OR branch: another user's search can never admit assistant-less foreign chunks.
+
+    f = QdrantVectorStore._scope_filter(None, None, None, assistant_id="a1")
+    assert f.must[0].key == "assistant_id" and f.must[0].match.value == "a1"
+
+
+def test_search_chunks_passes_assistant_scope(db, monkeypatch):
+    from app.rag import retrieve
+
+    seen = {}
+
+    class FakeStore:
+        def search(self, dense, sparse, limit, conversation_id=None, user_id=None,
+                   document_ids=None, assistant_id=None):  # noqa: ARG002
+            seen.update(user_id=user_id, assistant_id=assistant_id)
+            return []
+
+    monkeypatch.setattr(retrieve, "get_vector_store", lambda: FakeStore())
+    monkeypatch.setattr(retrieve, "embed_query", lambda q: [0.0])
+    monkeypatch.setattr(retrieve, "sparse_embed", lambda q: {"indices": [], "values": []})
+
+    retrieve.search_chunks(db, "q", user_id="u1", assistant_id="a1")
+    assert seen == {"user_id": "u1", "assistant_id": "a1"}
+
+
+def test_chunk_payload_includes_assistant_scope(db):
+    """Ingest + reindex payloads must carry assistant_id, or an admin reindex would strip
+    shared-KB scoping. Assistant docs are deployment-owned: no user_id in the payload."""
+    from app.models import DocChunk, Document
+    from app.rag.ingest import _payload
+    from app.rag.retrieve import build_chunk_payload
+
+    doc = Document(filename="kb.md", status="ready", assistant_id="a1", user_id=None)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    chunk = DocChunk(document_id=doc.id, ordinal=0, text="hello", embedding=[0.1])
+    db.add(chunk)
+    db.commit()
+    db.refresh(chunk)
+
+    for payload in (
+        _payload(doc, chunk),
+        build_chunk_payload(chunk, doc.filename, doc.conversation_id, doc.user_id, doc.assistant_id),
+    ):
+        assert payload["assistant_id"] == "a1"
+        assert "user_id" not in payload
+        assert "conversation_id" not in payload
+
+    db.delete(doc)
+    db.commit()
+
+
+def test_tool_context_carries_assistant_id(db):
+    from app.agent.harness import AgentSession
+    from app.agent.permissions import PermissionGate
+    from app.agent.registry import REGISTRY
+    from app.models import Conversation
+
+    conv = Conversation(title="t", user_id="u1", assistant_id="a1")
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+
+    gate = PermissionGate(db, REGISTRY, auto_approve=True)
+    session = AgentSession(db, conv, provider=None, registry=REGISTRY, gate=gate,
+                           params={}, profile="test", model=None)
+    assert session.ctx.assistant_id == "a1"
+    assert session.ctx.user_id == "u1"
+
+    db.delete(conv)
+    db.commit()
+
+
+def test_assistant_delete_cascades_documents(client, db):
+    from app.models import DocChunk, Document
+
+    a = _make_assistant(client, name="Doomed")
+    doc = Document(filename="kb.md", status="ready", assistant_id=a["id"], user_id=None)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    db.add(DocChunk(document_id=doc.id, ordinal=0, text="chunk"))
+    db.commit()
+    doc_id = doc.id
+
+    r = client.delete(f"/api/assistants/{a['id']}")
+    assert r.status_code == 200 and r.json()["documents_deleted"] == 1
+
+    db.expire_all()
+    assert db.get(Document, doc_id) is None
+    assert db.query(DocChunk).filter(DocChunk.document_id == doc_id).count() == 0
+
+
+def test_assistant_documents_hidden_from_personal_listing(client, db):
+    from app.models import Document
+
+    a = _make_assistant(client, name="Shared KB")
+    doc = Document(filename="shared.md", status="ready", assistant_id=a["id"], user_id=None)
+    db.add(doc)
+    db.commit()
+
+    # The personal documents endpoint (owner-scoped) must not include assistant docs.
+    personal = client.get("/api/documents").json()
+    assert all(d["id"] != doc.id for d in personal)
+
+    # The assistant KB endpoint lists them (admin-only).
+    kb = client.get(f"/api/assistants/{a['id']}/documents").json()
+    assert any(d["id"] == doc.id for d in kb)
+
+    client.delete(f"/api/assistants/{a['id']}")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -62,6 +62,25 @@ export const api = {
     return res.json()
   },
 
+  // assistants (reads for everyone; writes are admin-only server-side)
+  listAssistants: () => req('GET', '/api/assistants'),
+  createAssistant: (body) => req('POST', '/api/assistants', body),
+  updateAssistant: (id, body) => req('PATCH', `/api/assistants/${id}`, body),
+  deleteAssistant: (id) => req('DELETE', `/api/assistants/${id}`),
+  listAssistantDocuments: (id) => req('GET', `/api/assistants/${id}/documents`),
+  deleteAssistantDocument: (id, docId) => req('DELETE', `/api/assistants/${id}/documents/${docId}`),
+  uploadAssistantDocument: async (id, file) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch(`/api/assistants/${id}/documents`, {
+      method: 'POST',
+      body: fd,
+      headers: { ...authHeaders() },
+    })
+    if (!res.ok) throw new Error(await res.text())
+    return res.json()
+  },
+
   // mcp
   listMcp: () => req('GET', '/api/mcp'),
   addMcp: (body) => req('POST', '/api/mcp', body),

--- a/frontend/src/components/assistants/AssistantAvatar.jsx
+++ b/frontend/src/components/assistants/AssistantAvatar.jsx
@@ -1,0 +1,54 @@
+// Renders an assistant's avatar: uploaded image (data URL), emoji, or colored initials.
+const PALETTE = [
+  'bg-rose-500', 'bg-orange-500', 'bg-amber-500', 'bg-emerald-500',
+  'bg-teal-500', 'bg-sky-500', 'bg-indigo-500', 'bg-violet-500', 'bg-fuchsia-500',
+]
+
+function initials(name) {
+  const words = (name || '').trim().split(/\s+/).filter(Boolean)
+  if (!words.length) return '?'
+  return words.slice(0, 2).map((w) => w[0].toUpperCase()).join('')
+}
+
+function colorFor(name) {
+  let hash = 0
+  for (const ch of name || '') hash = (hash * 31 + ch.charCodeAt(0)) >>> 0
+  return PALETTE[hash % PALETTE.length]
+}
+
+export default function AssistantAvatar({ assistant, size = 32, className = '' }) {
+  const px = { width: size, height: size }
+  const name = assistant?.name || ''
+  const avatar = assistant?.avatar
+
+  if (avatar && avatar.startsWith('data:image/')) {
+    return (
+      <img
+        src={avatar}
+        alt={name}
+        style={px}
+        className={`shrink-0 rounded-full object-cover ${className}`}
+      />
+    )
+  }
+  if (avatar) {
+    return (
+      <span
+        style={{ ...px, fontSize: size * 0.6 }}
+        className={`flex shrink-0 items-center justify-center rounded-full bg-surface-2 leading-none ${className}`}
+        aria-label={name}
+      >
+        {avatar}
+      </span>
+    )
+  }
+  return (
+    <span
+      style={{ ...px, fontSize: size * 0.42 }}
+      className={`flex shrink-0 items-center justify-center rounded-full font-semibold text-white ${colorFor(name)} ${className}`}
+      aria-label={name}
+    >
+      {initials(name)}
+    </span>
+  )
+}

--- a/frontend/src/components/chat/Composer.jsx
+++ b/frontend/src/components/chat/Composer.jsx
@@ -52,6 +52,12 @@ export default function Composer() {
   const activeId = useStore((s) => s.activeId)
   const queued = useStore((s) => s.queued)
   const clearQueued = useStore((s) => s.clearQueued)
+  const assistants = useStore((s) => s.assistants)
+  const activeAssistantId = useStore((s) => s.activeAssistantId)
+  // Capability limits from the active assistant (also enforced server-side).
+  const caps = assistants.find((a) => a.id === activeAssistantId)?.capabilities || {}
+  const webSearchAllowed = caps.web_search !== false
+  const documentSearchAllowed = caps.document_search !== false
   const taRef = useRef(null)
   const fileRef = useRef(null)
   const imgRef = useRef(null)
@@ -151,8 +157,8 @@ export default function Composer() {
     // While streaming, the store queues this as a follow-up (steering).
     send(text.trim(), {
       autoApprove,
-      webSearch,
-      documentSearch,
+      webSearch: webSearch && webSearchAllowed,
+      documentSearch: documentSearch && documentSearchAllowed,
       images,
       documentIds,
       documentRefs,
@@ -389,13 +395,21 @@ export default function Composer() {
                 className="rounded border-border text-accent focus:ring-accent" />
               <Zap size={12} /> Agent mode
             </label>
-            <label className="flex cursor-pointer items-center gap-1.5" title="Allow live web search for this prompt">
-              <input type="checkbox" checked={webSearch} onChange={(e) => setWebSearch(e.target.checked)}
+            <label
+              className={`flex items-center gap-1.5 ${webSearchAllowed ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+              title={webSearchAllowed ? 'Allow live web search for this prompt' : 'Disabled by this assistant'}
+            >
+              <input type="checkbox" checked={webSearch && webSearchAllowed} disabled={!webSearchAllowed}
+                onChange={(e) => setWebSearch(e.target.checked)}
                 className="rounded border-border text-accent focus:ring-accent" />
               <Search size={12} /> Web search
             </label>
-            <label className="flex cursor-pointer items-center gap-1.5" title="Search uploaded documents for this prompt">
-              <input type="checkbox" checked={documentSearch} onChange={(e) => setDocumentSearch(e.target.checked)}
+            <label
+              className={`flex items-center gap-1.5 ${documentSearchAllowed ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+              title={documentSearchAllowed ? 'Search uploaded documents for this prompt' : 'Disabled by this assistant'}
+            >
+              <input type="checkbox" checked={documentSearch && documentSearchAllowed} disabled={!documentSearchAllowed}
+                onChange={(e) => setDocumentSearch(e.target.checked)}
                 className="rounded border-border text-accent focus:ring-accent" />
               <FileSearch size={12} /> Search documents
             </label>

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -3,6 +3,7 @@ import { Menu, Settings, Cpu, History, FolderOpen, LogOut, ShieldCheck } from 'l
 import { useStore } from '../../store/useStore'
 import CheckpointsModal from '../chat/CheckpointsModal'
 import WorkspaceFilesModal from '../chat/WorkspaceFilesModal'
+import AssistantAvatar from '../assistants/AssistantAvatar'
 
 export default function Header({ onToggleSidebar, onOpenSettings }) {
   const settings = useStore((s) => s.settings)
@@ -11,7 +12,10 @@ export default function Header({ onToggleSidebar, onOpenSettings }) {
   const user = useStore((s) => s.user)
   const authEnabled = useStore((s) => s.authConfig?.enabled)
   const logout = useStore((s) => s.logout)
+  const assistants = useStore((s) => s.assistants)
+  const activeAssistantId = useStore((s) => s.activeAssistantId)
   const activeProfile = providers.find((p) => p.name === settings?.active_profile)
+  const assistant = assistants.find((a) => a.id === activeAssistantId) || null
   const [checkpointsOpen, setCheckpointsOpen] = useState(false)
   const [filesOpen, setFilesOpen] = useState(false)
   const [userMenu, setUserMenu] = useState(false)
@@ -33,6 +37,21 @@ export default function Header({ onToggleSidebar, onOpenSettings }) {
         <span className="hidden sm:inline text-lg font-semibold text-content">Phlox</span>
       </div>
       <div className="flex items-center gap-2">
+        {activeAssistantId && (
+          <span
+            className="flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-sm text-content"
+            title={assistant?.description || (assistant ? assistant.name : 'This assistant is no longer available; the chat keeps its saved settings.')}
+          >
+            {assistant ? (
+              <>
+                <AssistantAvatar assistant={assistant} size={18} />
+                <span className="max-w-[140px] truncate">{assistant.name}</span>
+              </>
+            ) : (
+              <span className="max-w-[180px] truncate text-muted">Assistant unavailable</span>
+            )}
+          </span>
+        )}
         <button
           onClick={() => onOpenSettings('providers')}
           className="flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1.5 text-sm text-content hover:border-accent"
@@ -40,7 +59,7 @@ export default function Header({ onToggleSidebar, onOpenSettings }) {
         >
           <Cpu size={15} className="text-accent" />
           <span className="max-w-[180px] truncate">
-            {settings?.model || activeProfile?.label || 'Configure model'}
+            {(assistant?.model) || settings?.model || activeProfile?.label || 'Configure model'}
           </span>
         </button>
         {activeId && (

--- a/frontend/src/components/settings/AssistantsPanel.jsx
+++ b/frontend/src/components/settings/AssistantsPanel.jsx
@@ -1,0 +1,425 @@
+import { useEffect, useState } from 'react'
+import {
+  Bot, Plus, Trash2, Pencil, X, Upload, FileText, Loader2, CheckCircle, AlertCircle,
+  ImagePlus,
+} from 'lucide-react'
+import { api } from '../../api/client'
+import { useStore } from '../../store/useStore'
+import AssistantAvatar from '../assistants/AssistantAvatar'
+
+const BLANK = {
+  name: '',
+  description: '',
+  avatar: null,
+  profile: '',
+  model: '',
+  system_prompt: '',
+  prompt_suggestions: [],
+  capabilities: { web_search: true, document_search: true, tools: true },
+  visibility: 'public',
+}
+
+const CAPABILITIES = [
+  { key: 'web_search', label: 'Web search', hint: 'Allow the web-search tool' },
+  { key: 'document_search', label: 'Personal documents', hint: "Allow searching the user's own uploaded documents" },
+  { key: 'tools', label: 'Agent tools', hint: 'Allow code execution, shell, files, and MCP tools' },
+]
+
+// Downscale an image file to a small square data URL so avatars stay tiny.
+function fileToAvatarDataUrl(file, size = 128) {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+    img.onload = () => {
+      URL.revokeObjectURL(url)
+      const canvas = document.createElement('canvas')
+      canvas.width = size
+      canvas.height = size
+      const scale = Math.max(size / img.width, size / img.height)
+      const w = img.width * scale
+      const h = img.height * scale
+      canvas.getContext('2d').drawImage(img, (size - w) / 2, (size - h) / 2, w, h)
+      resolve(canvas.toDataURL('image/jpeg', 0.85))
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error('Could not read image'))
+    }
+    img.src = url
+  })
+}
+
+function Field({ label, hint, children }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-content">{label}</span>
+      {children}
+      {hint && <span className="mt-1 block text-[11px] text-muted">{hint}</span>}
+    </label>
+  )
+}
+
+const inputCls =
+  'w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-content outline-none focus:border-accent'
+
+function KnowledgeSection({ assistantId }) {
+  const [docs, setDocs] = useState([])
+  const [uploading, setUploading] = useState(false)
+
+  const load = () =>
+    api.listAssistantDocuments(assistantId).then(setDocs).catch(() => setDocs([]))
+
+  useEffect(() => {
+    if (!assistantId) return undefined
+    load()
+    const t = setInterval(load, 2500) // poll while ingestion runs
+    return () => clearInterval(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assistantId])
+
+  const upload = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    try {
+      await api.uploadAssistantDocument(assistantId, file)
+      await load()
+    } finally {
+      setUploading(false)
+      e.target.value = ''
+    }
+  }
+
+  const StatusIcon = ({ s }) =>
+    s === 'ready' ? <CheckCircle size={14} className="text-green-600" />
+    : s === 'error' ? <AlertCircle size={14} className="text-red-600" />
+    : <Loader2 size={14} className="animate-spin text-accent" />
+
+  if (!assistantId) {
+    return (
+      <p className="rounded-lg border border-dashed border-border bg-surface px-3 py-3 text-xs text-muted">
+        Save the assistant first, then upload knowledge-base documents here.
+      </p>
+    )
+  }
+
+  return (
+    <div>
+      <label className="mb-2 flex cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed border-border bg-surface px-3 py-4 text-sm text-content hover:border-accent">
+        <input type="file" className="hidden" onChange={upload} disabled={uploading}
+          accept=".pdf,.docx,.txt,.md,.markdown,.py,.js,.ts,.json,.csv,.html,.xml,.yaml,.yml" />
+        {uploading ? <Loader2 size={16} className="animate-spin text-accent" /> : <Upload size={16} className="text-accent" />}
+        {uploading ? 'Uploading…' : 'Upload a document'}
+      </label>
+      {docs.length === 0 && <p className="text-xs text-muted">No documents yet. Uploaded files are searchable by everyone using this assistant.</p>}
+      <div className="space-y-1.5">
+        {docs.map((d) => (
+          <div key={d.id} className="flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5">
+            <FileText size={15} className="shrink-0 text-accent" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-xs text-content">{d.filename}</div>
+              <div className="text-[11px] text-muted">
+                {(d.size_bytes / 1024).toFixed(0)} KB · {d.n_chunks} chunks{d.error ? ` · ${d.error}` : ''}
+              </div>
+            </div>
+            <StatusIcon s={d.status} />
+            <button
+              onClick={() => api.deleteAssistantDocument(assistantId, d.id).then(load)}
+              className="rounded p-1 text-muted hover:text-red-600"
+              title="Delete"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function AssistantEditor({ assistant, onSaved, onCancel }) {
+  const providers = useStore((s) => s.providers)
+  const [form, setForm] = useState(() => ({ ...BLANK, ...(assistant || {}) }))
+  const [models, setModels] = useState([])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const isNew = !assistant?.id
+
+  const patch = (p) => setForm((f) => ({ ...f, ...p }))
+
+  useEffect(() => {
+    if (!form.profile) {
+      setModels([])
+      return
+    }
+    api.getModels(form.profile)
+      .then(({ models: m }) => setModels(m || []))
+      .catch(() => setModels([]))
+  }, [form.profile])
+
+  const onAvatarFile = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    try {
+      patch({ avatar: await fileToAvatarDataUrl(file) })
+    } catch {
+      setError('Could not read that image.')
+    }
+    e.target.value = ''
+  }
+
+  const save = async () => {
+    setSaving(true)
+    setError('')
+    try {
+      const body = {
+        ...form,
+        profile: form.profile || null,
+        model: form.model || null,
+        description: form.description || null,
+        system_prompt: form.system_prompt || null,
+        prompt_suggestions: (form.prompt_suggestions || []).map((s) => s.trim()).filter(Boolean),
+      }
+      const saved = isNew
+        ? await api.createAssistant(body)
+        : await api.updateAssistant(assistant.id, body)
+      onSaved(saved)
+    } catch (err) {
+      setError(String(err.message || err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-2 p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-content">
+          {isNew ? 'New assistant' : `Edit ${assistant.name}`}
+        </h4>
+        <button onClick={onCancel} className="rounded p-1 text-muted hover:text-content" title="Close">
+          <X size={16} />
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-start gap-4">
+          <div className="flex flex-col items-center gap-1.5">
+            <AssistantAvatar assistant={form} size={64} />
+            <div className="flex gap-1">
+              <label className="cursor-pointer rounded p-1 text-muted hover:text-accent" title="Upload avatar image">
+                <input type="file" accept="image/*" className="hidden" onChange={onAvatarFile} />
+                <ImagePlus size={15} />
+              </label>
+              {form.avatar && (
+                <button onClick={() => patch({ avatar: null })} className="rounded p-1 text-muted hover:text-red-600" title="Remove avatar">
+                  <Trash2 size={15} />
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="flex-1 space-y-3">
+            <Field label="Name">
+              <input className={inputCls} value={form.name} placeholder="e.g. IT Assistant"
+                onChange={(e) => patch({ name: e.target.value })} />
+            </Field>
+            <Field label="Description" hint="Shown to users on the assistant picker.">
+              <input className={inputCls} value={form.description || ''}
+                placeholder="e.g. Helps with enterprise architecture questions"
+                onChange={(e) => patch({ description: e.target.value })} />
+            </Field>
+            <Field label="Avatar emoji" hint="Optional alternative to an image (e.g. 🤖).">
+              <input className={inputCls} value={form.avatar?.startsWith('data:image/') ? '' : form.avatar || ''}
+                placeholder="🤖" maxLength={16}
+                onChange={(e) => patch({ avatar: e.target.value || null })} />
+            </Field>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Provider profile" hint="Leave unset to follow each user's own model settings.">
+            <select className={inputCls} value={form.profile || ''}
+              onChange={(e) => patch({ profile: e.target.value, model: '' })}>
+              <option value="">User's default</option>
+              {providers.map((p) => (
+                <option key={p.name} value={p.name}>{p.label || p.name}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Model">
+            <select className={inputCls} value={form.model || ''} disabled={!form.profile}
+              onChange={(e) => patch({ model: e.target.value })}>
+              <option value="">{form.profile ? 'Profile default' : '—'}</option>
+              {models.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <Field label="System prompt" hint="Defines the persona and role. Edits apply to existing chats with this assistant too.">
+          <textarea className={`${inputCls} min-h-[110px] resize-y`} value={form.system_prompt || ''}
+            placeholder="You are a helpful IT Architecture Assistant named Bridget…"
+            onChange={(e) => patch({ system_prompt: e.target.value })} />
+        </Field>
+
+        <Field label="Prompt suggestions" hint="Starter prompts shown on the new-chat screen.">
+          <div className="space-y-1.5">
+            {(form.prompt_suggestions || []).map((s, i) => (
+              <div key={i} className="flex gap-1.5">
+                <input className={inputCls} value={s}
+                  placeholder="e.g. Who are you and what can you help with?"
+                  onChange={(e) =>
+                    patch({
+                      prompt_suggestions: form.prompt_suggestions.map((v, j) => (j === i ? e.target.value : v)),
+                    })
+                  } />
+                <button
+                  onClick={() => patch({ prompt_suggestions: form.prompt_suggestions.filter((_, j) => j !== i) })}
+                  className="rounded p-1.5 text-muted hover:text-red-600" title="Remove"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ))}
+            <button
+              onClick={() => patch({ prompt_suggestions: [...(form.prompt_suggestions || []), ''] })}
+              className="flex items-center gap-1 rounded px-1 py-0.5 text-xs text-accent hover:underline"
+            >
+              <Plus size={13} /> Add suggestion
+            </button>
+          </div>
+        </Field>
+
+        <Field label="Capabilities" hint="Unchecked capabilities are blocked for everyone using this assistant.">
+          <div className="flex flex-wrap gap-x-5 gap-y-1.5">
+            {CAPABILITIES.map((c) => (
+              <label key={c.key} className="flex cursor-pointer items-center gap-1.5 text-sm text-content" title={c.hint}>
+                <input type="checkbox"
+                  checked={form.capabilities?.[c.key] !== false}
+                  onChange={(e) =>
+                    patch({ capabilities: { ...form.capabilities, [c.key]: e.target.checked } })
+                  }
+                  className="rounded border-border text-accent focus:ring-accent" />
+                {c.label}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Visibility">
+          <select className={inputCls} value={form.visibility}
+            onChange={(e) => patch({ visibility: e.target.value })}>
+            <option value="public">Public — all users can chat with it</option>
+            <option value="private">Private — only you (and admins)</option>
+          </select>
+        </Field>
+
+        <Field label="Knowledge base" hint="Documents every user of this assistant can search. Model choice is fixed per chat at creation; prompt edits apply everywhere.">
+          <KnowledgeSection assistantId={assistant?.id} />
+        </Field>
+
+        {error && <p className="text-xs text-red-600">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button onClick={onCancel} className="rounded-lg border border-border px-3 py-1.5 text-sm text-content hover:bg-surface-3">
+            Cancel
+          </button>
+          <button onClick={save} disabled={saving || !form.name.trim()}
+            className="rounded-lg bg-accent px-4 py-1.5 text-sm font-medium text-accent-fg hover:opacity-90 disabled:opacity-40">
+            {saving ? 'Saving…' : isNew ? 'Create assistant' : 'Save changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AssistantsPanel() {
+  const [assistants, setAssistants] = useState([])
+  const [editing, setEditing] = useState(null) // null | 'new' | assistant object
+  const loadGlobal = useStore((s) => s.loadAssistants)
+
+  const load = () => api.listAssistants().then(setAssistants).catch(() => setAssistants([]))
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const refresh = async () => {
+    await load()
+    loadGlobal() // keep the chat picker in sync
+  }
+
+  const remove = async (a) => {
+    if (!window.confirm(`Delete "${a.name}" and its knowledge base? Existing chats keep working with their saved settings.`)) return
+    await api.deleteAssistant(a.id)
+    if (editing?.id === a.id) setEditing(null)
+    await refresh()
+  }
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-content">Assistants</h3>
+        {!editing && (
+          <button onClick={() => setEditing('new')}
+            className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-sm font-medium text-accent-fg hover:opacity-90">
+            <Plus size={15} /> New assistant
+          </button>
+        )}
+      </div>
+      <p className="mb-4 text-xs text-muted">
+        Curated personas built on your configured models: a custom system prompt, an optional
+        knowledge base, starter prompts, and capability limits. Users pick one when starting a chat.
+      </p>
+
+      {editing && (
+        <div className="mb-4">
+          <AssistantEditor
+            assistant={editing === 'new' ? null : editing}
+            onSaved={async (saved) => {
+              await refresh()
+              // Keep the editor open on create so the admin can upload KB documents.
+              setEditing(editing === 'new' ? saved : null)
+            }}
+            onCancel={() => setEditing(null)}
+          />
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {assistants.length === 0 && !editing && (
+          <div className="flex flex-col items-center rounded-xl border border-dashed border-border bg-surface px-4 py-8 text-center">
+            <Bot size={22} className="mb-2 text-accent" />
+            <p className="text-sm text-content">No assistants yet.</p>
+            <p className="text-xs text-muted">Create one to give your users a purpose-built persona.</p>
+          </div>
+        )}
+        {assistants.map((a) => (
+          <div key={a.id} className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2">
+            <AssistantAvatar assistant={a} size={34} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium text-content">{a.name}</span>
+                {a.visibility === 'private' && (
+                  <span className="rounded bg-surface-3 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted">private</span>
+                )}
+              </div>
+              <div className="truncate text-xs text-muted">
+                {a.model || 'user default model'} · {a.n_documents} doc{a.n_documents === 1 ? '' : 's'}
+                {a.description ? ` · ${a.description}` : ''}
+              </div>
+            </div>
+            <button onClick={() => setEditing(a)} className="rounded p-1.5 text-muted hover:text-accent" title="Edit">
+              <Pencil size={15} />
+            </button>
+            <button onClick={() => remove(a)} className="rounded p-1.5 text-muted hover:text-red-600" title="Delete">
+              <Trash2 size={15} />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/SettingsDrawer.jsx
+++ b/frontend/src/components/settings/SettingsDrawer.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal, Wallet } from 'lucide-react'
+import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal, Wallet, Bot } from 'lucide-react'
 import ProviderSettings from './ProviderSettings'
+import AssistantsPanel from './AssistantsPanel'
 import ThemeSwitcher from './ThemeSwitcher'
 import MemoryPanel from './MemoryPanel'
 import UsersPanel from './UsersPanel'
@@ -23,6 +24,7 @@ const USER_TABS = [
   { id: 'apikeys', label: 'API Keys', icon: KeySquare },
 ]
 const ADMIN_TABS = [
+  { id: 'assistants', label: 'Assistants', icon: Bot },
   { id: 'users', label: 'Users', icon: Users },
   { id: 'usage', label: 'Usage & Cost', icon: BarChart3 },
   { id: 'budgets', label: 'Budgets', icon: Wallet },
@@ -185,6 +187,7 @@ export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
             {tab === 'documents' && <DocumentsPanel />}
             {tab === 'memory' && <MemoryPanel />}
             {tab === 'apikeys' && <ApiKeysPanel />}
+            {isAdmin && tab === 'assistants' && <AssistantsPanel />}
             {isAdmin && tab === 'mcp' && <McpManager />}
             {isAdmin && tab === 'tools' && <ToolManager />}
             {isAdmin && tab === 'users' && <UsersPanel />}

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Ban } from 'lucide-react'
 import Message from '../components/chat/Message'
 import Composer from '../components/chat/Composer'
 import ApprovalPrompt from '../components/chat/ApprovalPrompt'
+import AssistantAvatar from '../components/assistants/AssistantAvatar'
 import { useStore } from '../store/useStore'
 
 const fmtUsd = (n) =>
@@ -52,16 +53,66 @@ const SUGGESTIONS = [
 
 function Welcome() {
   const send = useStore((s) => s.sendMessage)
+  const assistants = useStore((s) => s.assistants)
+  const activeAssistantId = useStore((s) => s.activeAssistantId)
+  const selectAssistant = useStore((s) => s.selectAssistant)
+  const assistant = assistants.find((a) => a.id === activeAssistantId) || null
+
+  const suggestions = assistant?.prompt_suggestions?.length
+    ? assistant.prompt_suggestions.map((text) => ({ text }))
+    : assistant
+      ? []
+      : SUGGESTIONS
+
   return (
     <div className="flex h-full flex-col items-center justify-center px-4 text-center">
-      <img src="/phlox-logo.svg" alt="Phlox" className="mb-6 h-14" />
-      <h1 className="mb-2 text-2xl font-semibold text-content">How can I help you today?</h1>
+      {assistant ? (
+        <AssistantAvatar assistant={assistant} size={56} className="mb-6" />
+      ) : (
+        <img src="/phlox-logo.svg" alt="Phlox" className="mb-6 h-14" />
+      )}
+      <h1 className="mb-2 text-2xl font-semibold text-content">
+        {assistant ? assistant.name : 'How can I help you today?'}
+      </h1>
       <p className="mb-8 max-w-md text-muted">
-        Chat, run code, search your documents, and use connected tools — powered by your
-        choice of model provider.
+        {assistant
+          ? assistant.description || 'Ask me anything in my area of expertise.'
+          : 'Chat, run code, search your documents, and use connected tools — powered by your choice of model provider.'}
       </p>
+
+      {assistants.length > 0 && (
+        <div className="mb-8 flex w-full max-w-2xl flex-wrap justify-center gap-2">
+          <button
+            onClick={() => selectAssistant(null)}
+            className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm ${
+              !assistant
+                ? 'border-accent bg-surface-2 text-content'
+                : 'border-border bg-surface text-muted hover:border-accent'
+            }`}
+          >
+            <img src="/phlox-logo.svg" alt="" className="h-4" />
+            Phlox
+          </button>
+          {assistants.map((a) => (
+            <button
+              key={a.id}
+              onClick={() => selectAssistant(a.id)}
+              title={a.description || a.name}
+              className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm ${
+                a.id === activeAssistantId
+                  ? 'border-accent bg-surface-2 text-content'
+                  : 'border-border bg-surface text-muted hover:border-accent'
+              }`}
+            >
+              <AssistantAvatar assistant={a} size={20} />
+              {a.name}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="grid w-full max-w-2xl grid-cols-1 gap-2 sm:grid-cols-2">
-        {SUGGESTIONS.map((s) => (
+        {suggestions.map((s) => (
           <button
             key={s.text}
             onClick={() => send(s.text, { documentSearch: Boolean(s.documentSearch) })}

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -16,6 +16,9 @@ export const useStore = create((set, get) => ({
   messages: [],
   settings: null,
   providers: [],
+  assistants: [],
+  // Assistant for the active conversation (pinned server-side) or the pending new chat.
+  activeAssistantId: null,
   theme: initialTheme(),
 
   streaming: false,
@@ -67,7 +70,28 @@ export const useStore = create((set, get) => ({
   async loadApp() {
     await Promise.all([
       get().loadConversations(), get().loadSettings(), get().loadProviders(), get().loadBudget(),
+      get().loadAssistants(),
     ])
+  },
+
+  async loadAssistants() {
+    try {
+      const assistants = await api.listAssistants()
+      set({ assistants })
+    } catch {
+      set({ assistants: [] })
+    }
+  },
+
+  // The active assistant object, or null (also null when it no longer resolves — deleted).
+  activeAssistant() {
+    const { assistants, activeAssistantId } = get()
+    return assistants.find((a) => a.id === activeAssistantId) || null
+  },
+
+  // Pick an assistant for the next new chat (only meaningful on the Welcome screen).
+  selectAssistant(id) {
+    set({ activeAssistantId: id || null })
   },
 
   // Monthly budget status (drives the chat warning/block banner). Refreshed after each
@@ -97,7 +121,10 @@ export const useStore = create((set, get) => ({
 
   logout() {
     setToken(null)
-    set({ user: null, conversations: [], messages: [], activeId: null, live: null, canvas: null })
+    set({
+      user: null, conversations: [], messages: [], activeId: null, live: null, canvas: null,
+      assistants: [], activeAssistantId: null,
+    })
   },
 
   async loadConversations() {
@@ -140,16 +167,22 @@ export const useStore = create((set, get) => ({
   async selectConversation(id) {
     if (get().streaming) get().stopStreaming()
     if (!id) {
-      set({ activeId: null, messages: [], live: null, canvas: null })
+      set({ activeId: null, messages: [], live: null, canvas: null, activeAssistantId: null })
       return
     }
     const conv = await api.getConversation(id)
-    set({ activeId: id, messages: conv.messages, live: null, canvas: null })
+    set({
+      activeId: id,
+      messages: conv.messages,
+      live: null,
+      canvas: null,
+      activeAssistantId: conv.assistant_id || null,
+    })
   },
 
   newConversation() {
     if (get().streaming) get().stopStreaming()
-    set({ activeId: null, messages: [], live: null, error: null, canvas: null })
+    set({ activeId: null, messages: [], live: null, error: null, canvas: null, activeAssistantId: null })
   },
 
   async deleteConversation(id) {
@@ -238,6 +271,9 @@ export const useStore = create((set, get) => ({
       document_search: documentSearch,
       document_ids: documentIds,
       images,
+      // Only meaningful for a new conversation; the server pins it there and ignores
+      // it on existing ones.
+      assistant_id: get().activeAssistantId,
     }
 
     const abortFn = streamChat(


### PR DESCRIPTION
🎭 **Custom assistants**

admins define named personas (name, avatar, description) on top of any configured base model, with a custom **system prompt**, **starter prompt suggestions**, an optional shared **knowledge base** (documents all users of the assistant can search), and per-assistant **capability limits** (web search / personal-document search / agent tools). Users pick an assistant on the new-chat screen; the choice is pinned per conversation.

## What this PR includes

**Admins create assistants** (Settings → new "Assistants" admin tab): name, description, avatar (uploaded image auto-resized to a small data URL, an emoji, or auto-generated initials), base model (provider profile + model, or "user's default"), system prompt, prompt suggestions, capability limits, public/private visibility, and a knowledge base with drag-in document upload. **Users pick one** via chips on the Welcome screen — the persona's avatar/description and its starter prompts replace the defaults, and a pill in the header shows the active assistant. The assistant is pinned per conversation; switching means starting a new chat.

Key backend mechanics:
- New `assistants` table plus nullable `assistant_id` columns on `conversations` and `documents` (added via the existing `_ADDED_COLUMNS` startup migration — no data loss). New router at [assistants.py](backend/app/routers/assistants.py): reads for all users, writes admin-gated, with `created_by`/`visibility` already in place so user-created assistants can be enabled later by just relaxing the POST gate.
- **Knowledge bases are deployment-owned** (`user_id=NULL`, `assistant_id=<id>`): they survive the creating admin's deletion, never appear in anyone's personal Documents panel or @-picker, and are shared across users via a widened Qdrant scope filter in [store.py](backend/app/rag/store.py). The widening only ever happens with a visibility-checked assistant id resolved in [chat.py](backend/app/routers/chat.py) — request-body spoofing is blocked because existing conversations always use their pinned assistant.
- Chat precedence: request → assistant → user settings for profile/model (resolved before the budget gate so spend meters the assistant's model). The assistant's config is snapshotted onto the conversation at creation, so deleting an assistant degrades old threads gracefully; prompt edits propagate live to existing chats.
- Capabilities are hard server-side limits mirrored as disabled toggles in the composer: `web_search` off strips the tool, `tools` off reduces the agent to chat + knowledge only, and an attached KB force-enables `search_documents` with a KB-specific prompt.

## Verification

- All **15 new tests** in [test_assistants.py](backend/tests/test_assistants.py) pass, plus the full backend suite (118 passed) and `ruff` clean; frontend builds without errors.
- Live E2E against your dev servers: created the IT Assistant with a KB doc, and it answered "What is our approved enterprise message queue platform?" as Bridget with "**Apache Pulsar** … [1]" — grounded via `search_documents`. A second non-admin user got the same KB-grounded answers but couldn't see the KB doc in their library or hit any admin endpoint (403s confirmed). Deleted-assistant fallback, reindex payload preservation, and the disabled web-search toggle were all exercised.

Two notes: the `document_search` capability disables the user's *personal* doc-search toggle, but a user's own documents remain reachable when the assistant KB search runs (their own data, so no exposure); and per-assistant generation params (temperature etc.) are schema-ready but have no editor UI yet, per our discussion. Both servers are still running if you want to poke around; the work is on the `custom_assistants` branch, uncommitted — say the word and I'll commit it.

closes #6 