### PR TITLE
Add Agent Skills: reusable, invokable workflows for the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ models).
   assistant can search), and per-assistant **capability limits** (web search /
   personal-document search / agent tools). Users pick an assistant on the new-chat screen;
   the choice is pinned per conversation.
+- ✨ **Agent skills** — named, reusable markdown workflows the agent can follow
+  ([Anthropic Agent Skills](https://github.com/anthropics/skills)–compatible, with
+  SKILL.md import/export): invoke one explicitly with a **`/` slash command** in the
+  composer, or let the agent **auto-activate** relevant skills via progressive disclosure
+  (opt-out toggle). Users manage private skills; admins publish shared ones. See
+  [docs/SKILLS.md](docs/SKILLS.md).
 - 🧠 **Cross-conversation memory** — durable facts recalled across chats.
 - 🖼️ **Multimodal** — attach images to messages for vision models.
 - 🔌 **MCP integration** — connect Model Context Protocol servers; their tools join
@@ -91,6 +97,7 @@ models).
 | [docs/BUDGETS.md](docs/BUDGETS.md) | Monthly spend budgets per user/department: warnings + enforcement |
 | [docs/API_GATEWAY.md](docs/API_GATEWAY.md) | OpenAI-compatible API gateway: API keys + `/v1/*` endpoints |
 | [docs/MCP.md](docs/MCP.md) | Connecting MCP servers |
+| [docs/SKILLS.md](docs/SKILLS.md) | Agent skills: slash commands, auto-activation, SKILL.md import/export |
 | [docs/THEMING.md](docs/THEMING.md) | The theme token system + adding themes |
 | [docs/ADDING_A_TOOL.md](docs/ADDING_A_TOOL.md) · [docs/ADDING_A_PROVIDER.md](docs/ADDING_A_PROVIDER.md) | Extension guides |
 | [AGENTS.md](AGENTS.md) | Orientation for AI coding agents working on the repo |

--- a/backend/app/agent/tools/__init__.py
+++ b/backend/app/agent/tools/__init__.py
@@ -17,6 +17,7 @@ def register_builtin_tools(registry: "ToolRegistry") -> None:
         memory,
         planning,
         shell,
+        skills,
         subagent,
         web,
     )
@@ -34,6 +35,7 @@ def register_builtin_tools(registry: "ToolRegistry") -> None:
         web.WebSearch(),
         web.WebFetch(),
         memory.SaveMemory(),
+        skills.UseSkill(),
         subagent.SpawnSubagent(),
         planning.UpdateTodos(),
         checkpoint.CreateCheckpoint(),

--- a/backend/app/agent/tools/skills.py
+++ b/backend/app/agent/tools/skills.py
@@ -1,0 +1,48 @@
+"""use_skill — the model-side half of skill auto-activation (progressive disclosure).
+
+The system prompt lists auto-activatable skills as name + description only (see
+``app.skills.skills_preamble``); this tool loads a skill's full instructions on demand so
+unused skills cost no context. Visibility is enforced against the conversation owner
+(``ctx.user_id``), the same boundary the /api/skills routes use.
+"""
+from __future__ import annotations
+
+from app.agent.tools.base import Tool, ToolContext, ToolResult
+
+
+class UseSkill(Tool):
+    name = "use_skill"
+    description = (
+        "Load the full instructions of a registered skill by name. Call this before "
+        "attempting a task that matches a skill listed under 'Skills' in your system "
+        "prompt, then follow the returned instructions."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "The skill's registered name (e.g. 'data-analysis').",
+            }
+        },
+        "required": ["name"],
+    }
+    category = "skills"
+    default_permission = "auto"
+
+    def run(self, ctx: ToolContext, name: str = "", **kwargs) -> ToolResult:
+        from app.skills import resolve_skill, visible_skills
+
+        skill = resolve_skill(ctx.db, name, ctx.user_id)
+        if skill is None:
+            available = ", ".join(s.name for s in visible_skills(ctx.db, ctx.user_id)) or "(none)"
+            return ToolResult(
+                content=f"Unknown skill '{name}'. Available skills: {available}",
+                is_error=True,
+            )
+        return ToolResult(
+            content=(
+                f"Skill '{skill.name}' loaded. Follow these instructions for the "
+                f"current task:\n\n{skill.instructions}"
+            )
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ from app.routers import (
     memories,
     providers,
     settings,
+    skills,
     tools,
     usage,
 )
@@ -75,6 +76,14 @@ def _bootstrap() -> None:
             backfill_usage_ledger(db)
         except Exception as e:  # noqa: BLE001
             logger.warning("Usage ledger backfill skipped: %s", e)
+
+        # Seed the example skills on first boot (no-op once the table has rows).
+        try:
+            from app.skills import seed_builtin_skills
+
+            seed_builtin_skills(db)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Skill seeding skipped: %s", e)
 
         # Auto-connect enabled MCP servers.
         from app.mcp.manager import mcp_manager
@@ -122,7 +131,7 @@ app.add_middleware(
 
 for r in (auth, chat, conversations, providers, settings, documents, assistants, mcp,
           tools, files, memories, checkpoints, attachments, usage, admin_config, api_keys,
-          gateway, budgets):
+          gateway, budgets, skills):
     app.include_router(r.router)
 
 # Structured request logging (always) + OpenTelemetry tracing (if configured).

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -94,6 +94,40 @@ class Assistant(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=_now, onupdate=_now)
 
 
+class Skill(Base):
+    """A registered agent skill: named, reusable markdown instructions the model can
+    follow for a specialized task (Anthropic Agent Skills / SKILL.md compatible).
+
+    Two activation paths (see docs/SKILLS.md):
+    - **Explicit**: the user invokes ``/name`` in the composer; the full ``instructions``
+      are injected into the system prompt for that turn.
+    - **Automatic** (progressive disclosure): skills with ``auto_activate`` are listed in
+      the system prompt as name + description only; the model calls the ``use_skill``
+      tool to load the full instructions when a request matches.
+
+    Users create their own (``visibility='private'``); admins can publish ``public``
+    skills for everyone. ``name`` is the global slash-command handle, so it is unique.
+    """
+
+    __tablename__ = "skills"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True, default=_uuid)
+    # Slug handle ("data-analysis") — what users type after "/" and models pass to use_skill.
+    name: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    # Shown to the model when deciding whether to load the skill — say what it does AND
+    # when to use it (this is the trigger, per the Agent Skills spec).
+    description: Mapped[str] = mapped_column(Text)
+    # The SKILL.md body: full markdown instructions followed once the skill is active.
+    instructions: Mapped[str] = mapped_column(Text)
+    # When true, advertised to the model for self-serve activation via use_skill.
+    auto_activate: Mapped[bool] = mapped_column(Boolean, default=True)
+    visibility: Mapped[str] = mapped_column(String(20), default="private")  # public | private
+    created_by: Mapped[str | None] = mapped_column(String(32), index=True, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=_now, onupdate=_now)
+
+
 class Conversation(Base):
     __tablename__ = "conversations"
 

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -77,6 +77,14 @@ def _build_history(conversation: Conversation, system_prompt: str) -> list[dict]
                 names = ", ".join(a.get("filename") or "document" for a in doc_refs)
                 marker = f"[Referenced documents: {names}]"
                 content = f"{content}\n\n{marker}" if content else marker
+            # Full skill instructions are only injected for the *current* turn (they'd
+            # bloat every later turn); the marker keeps the model aware a skill guided
+            # this message, and it can reload one via use_skill if needed.
+            skill_refs = [a for a in (m.attachments or []) if a.get("type") == "skill"]
+            if skill_refs:
+                names = ", ".join(a.get("name") or "skill" for a in skill_refs)
+                marker = f"[Invoked skills: {names}]"
+                content = f"{content}\n\n{marker}" if content else marker
             entry = {"role": "user", "content": content}
             if m.attachments:
                 from app.attachments import load_image_data_urls
@@ -166,6 +174,19 @@ def _resolve_document_refs(
             continue
         resolved.append(doc)
     return resolved
+
+
+def _latest_user_skill_names(conversation: Conversation) -> list[str]:
+    """Skill slugs invoked on the most recent user message (for regenerate)."""
+    for message in reversed(list(conversation.messages)):
+        if message.role != "user":
+            continue
+        return [
+            ref.get("name")
+            for ref in (message.attachments or [])
+            if ref.get("type") == "skill" and ref.get("name")
+        ]
+    return []
 
 
 def _latest_user_document_ids(conversation: Conversation) -> list[str]:
@@ -388,6 +409,28 @@ async def chat(
         is not None
     )
 
+    # Skills the user explicitly invoked ("/name"): inject their full instructions for
+    # this turn. Visibility is checked in resolve_skill; unknown/hidden slugs are dropped.
+    from app.skills import invoked_skills_prompt, resolve_skill, skills_preamble
+
+    skill_names = _latest_user_skill_names(conversation) if req.regenerate else req.skills
+    invoked_skills = []
+    seen_skills: set[str] = set()
+    for name in skill_names:
+        s = resolve_skill(db, name, user.id)
+        if s and s.name not in seen_skills:
+            seen_skills.add(s.name)
+            invoked_skills.append(s)
+    if invoked_skills:
+        system_prompt += invoked_skills_prompt(invoked_skills)
+
+    # Progressive disclosure for auto-activation: list name+description only; the model
+    # loads full instructions via use_skill. Needs the tools capability (it IS a tool).
+    skill_listing = ""
+    if req.skills_enabled and caps.get("tools", True):
+        skill_listing = skills_preamble(db, user.id, exclude=seen_skills)
+        system_prompt += skill_listing
+
     if assistant_has_kb:
         system_prompt += ASSISTANT_KB_PROMPT
     elif document_search_requested:
@@ -413,6 +456,9 @@ async def chat(
 
             attachment_refs.extend(save_message_images(user_msg.id, req.images))
         attachment_refs.extend(_document_attachment(doc) for doc in referenced_docs)
+        attachment_refs.extend(
+            {"type": "skill", "skill_id": s.id, "name": s.name} for s in invoked_skills
+        )
         if attachment_refs:
             user_msg.attachments = attachment_refs
             db.commit()
@@ -456,6 +502,9 @@ async def chat(
             # point of attaching one.
             if not (document_search_requested or referenced_docs or assistant_has_kb):
                 enabled_tools.discard("search_documents")
+            # Only advertise use_skill when the prompt actually lists skills to load.
+            if not skill_listing:
+                enabled_tools.discard("use_skill")
             if not caps.get("tools", True):
                 # Chat + knowledge only: no code execution, shell, files, or MCP tools.
                 enabled_tools &= {"web_search", "search_documents"}

--- a/backend/app/routers/skills.py
+++ b/backend/app/routers/skills.py
@@ -1,0 +1,171 @@
+"""Agent skills: CRUD + SKILL.md import/export.
+
+Any authenticated user can create skills; non-admins are forced to ``private``
+(visible/invocable only by them), admins can publish ``public`` skills for everyone.
+``name`` is the global slash-command handle, so it is unique across the deployment.
+Import/export speaks the Anthropic Agent Skills SKILL.md format (YAML frontmatter +
+markdown body) for interop with the anthropics/skills ecosystem.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from app.auth.deps import get_current_user
+from app.database import get_db
+from app.models import Skill, User
+from app.schemas import SkillCreate, SkillOut, SkillUpdate
+from app.skills import (
+    MAX_DESCRIPTION_LEN,
+    MAX_INSTRUCTIONS_LEN,
+    parse_skill_md,
+    render_skill_md,
+    slugify,
+    visible_skills,
+)
+
+router = APIRouter(prefix="/api/skills", tags=["skills"])
+
+MAX_IMPORT_BYTES = 512 * 1024
+
+
+def _visible(db: Session, skill_id: str, user: User) -> Skill:
+    s = db.get(Skill, skill_id)
+    if not s or (s.visibility != "public" and s.created_by != user.id and user.role != "admin"):
+        raise HTTPException(404, "Skill not found")
+    return s
+
+
+def _require_owner(db: Session, skill_id: str, user: User) -> Skill:
+    s = _visible(db, skill_id, user)
+    if user.role != "admin" and s.created_by != user.id:
+        raise HTTPException(403, "Only the skill's creator or an admin can modify it")
+    return s
+
+
+def _check_fields(name: str, description: str, instructions: str) -> str:
+    """Normalize the slug and enforce the size caps. Returns the slug."""
+    slug = slugify(name)
+    if not slug:
+        raise HTTPException(422, "Skill name must contain letters or digits")
+    if len(description) > MAX_DESCRIPTION_LEN:
+        raise HTTPException(422, f"Description too long (max {MAX_DESCRIPTION_LEN} chars)")
+    if len(instructions) > MAX_INSTRUCTIONS_LEN:
+        raise HTTPException(422, f"Instructions too long (max {MAX_INSTRUCTIONS_LEN} chars)")
+    return slug
+
+
+def _check_name_free(db: Session, slug: str, skill_id: str | None = None) -> None:
+    q = db.query(Skill.id).filter(Skill.name == slug)
+    if skill_id:
+        q = q.filter(Skill.id != skill_id)
+    if q.first() is not None:
+        raise HTTPException(409, f"A skill named '{slug}' already exists")
+
+
+def _effective_visibility(requested: str, user: User) -> str:
+    # Publishing to everyone is an admin decision; silently keep user skills private.
+    return requested if user.role == "admin" else "private"
+
+
+def _create(db: Session, body: SkillCreate, user: User) -> Skill:
+    slug = _check_fields(body.name, body.description, body.instructions)
+    _check_name_free(db, slug)
+    s = Skill(
+        name=slug,
+        description=body.description,
+        instructions=body.instructions,
+        auto_activate=body.auto_activate,
+        visibility=_effective_visibility(body.visibility, user),
+        created_by=user.id,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+@router.get("", response_model=list[SkillOut])
+def list_skills(db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    if user.role == "admin":
+        # Admins manage all skills, including other users' private ones and inactive rows.
+        return db.query(Skill).order_by(Skill.name).all()
+    return visible_skills(db, user.id, include_inactive=True)
+
+
+@router.post("", response_model=SkillOut)
+def create_skill(
+    body: SkillCreate, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    return _create(db, body, user)
+
+
+@router.post("/import", response_model=SkillOut)
+async def import_skill(
+    file: UploadFile, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    """Import an Agent Skills SKILL.md file (YAML frontmatter + markdown body)."""
+    raw = await file.read(MAX_IMPORT_BYTES + 1)
+    if len(raw) > MAX_IMPORT_BYTES:
+        raise HTTPException(413, "Skill file too large")
+    try:
+        parsed = parse_skill_md(raw.decode("utf-8"))
+    except UnicodeDecodeError as e:
+        raise HTTPException(422, "Skill file must be UTF-8 text") from e
+    except ValueError as e:
+        raise HTTPException(422, str(e)) from e
+    return _create(db, SkillCreate(**parsed), user)
+
+
+@router.get("/{skill_id}", response_model=SkillOut)
+def get_skill(skill_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)):
+    return _visible(db, skill_id, user)
+
+
+@router.get("/{skill_id}/export", response_class=PlainTextResponse)
+def export_skill(
+    skill_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    s = _visible(db, skill_id, user)
+    return PlainTextResponse(
+        render_skill_md(s),
+        media_type="text/markdown; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{s.name}-SKILL.md"'},
+    )
+
+
+@router.patch("/{skill_id}", response_model=SkillOut)
+def update_skill(
+    skill_id: str,
+    body: SkillUpdate,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    s = _require_owner(db, skill_id, user)
+    updates = body.model_dump(exclude_unset=True)
+    if "visibility" in updates:
+        updates["visibility"] = _effective_visibility(updates["visibility"], user)
+    slug = _check_fields(
+        updates.get("name", s.name),
+        updates.get("description", s.description),
+        updates.get("instructions", s.instructions),
+    )
+    if "name" in updates:
+        _check_name_free(db, slug, skill_id=s.id)
+        updates["name"] = slug
+    for key, value in updates.items():
+        setattr(s, key, value)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+@router.delete("/{skill_id}")
+def delete_skill(
+    skill_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
+):
+    s = _require_owner(db, skill_id, user)
+    db.delete(s)
+    db.commit()
+    return {"deleted": skill_id}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -163,6 +163,61 @@ class AssistantOut(AssistantBase):
         from_attributes = True
 
 
+# -- skills ------------------------------------------------------------------
+class SkillBase(BaseModel):
+    # Slug handle; the router normalizes via app.skills.slugify, this just rejects empties.
+    name: str
+    # What the skill does AND when to use it — the model-facing activation trigger.
+    description: str
+    # Full markdown instructions (the SKILL.md body).
+    instructions: str
+    # Advertise to the model for self-serve activation via the use_skill tool.
+    auto_activate: bool = True
+    visibility: str = "private"  # public | private (public requires admin)
+
+    @field_validator("visibility")
+    @classmethod
+    def _check_visibility(cls, v: str) -> str:
+        return _validate_visibility(v)
+
+    @field_validator("name", "description")
+    @classmethod
+    def _check_required_text(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("field is required")
+        return v
+
+
+class SkillCreate(SkillBase):
+    pass
+
+
+class SkillUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    instructions: str | None = None
+    auto_activate: bool | None = None
+    visibility: str | None = None
+    is_active: bool | None = None
+
+    @field_validator("visibility")
+    @classmethod
+    def _check_visibility(cls, v: str | None) -> str | None:
+        return _validate_visibility(v)
+
+
+class SkillOut(SkillBase):
+    id: str
+    created_by: str | None = None
+    is_active: bool = True
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 # -- chat ------------------------------------------------------------------
 class ChatRequest(BaseModel):
     conversation_id: str | None = None
@@ -185,6 +240,12 @@ class ChatRequest(BaseModel):
     regenerate: bool = False
     # Base64 data URLs of attached images (data:image/...;base64,...).
     images: list[str] = []
+    # Skill slugs the user explicitly invoked ("/name" in the composer) for this message;
+    # their full instructions are injected into the system prompt for this turn.
+    skills: list[str] = []
+    # When true, advertise registered skills (name + description) and the use_skill tool
+    # so the model can load relevant skills on its own (progressive disclosure).
+    skills_enabled: bool = True
 
 
 class ApproveRequest(BaseModel):

--- a/backend/app/skills.py
+++ b/backend/app/skills.py
@@ -1,0 +1,241 @@
+"""Agent skills: reusable markdown instructions, SKILL.md-compatible.
+
+A skill is a named set of markdown instructions (plus a trigger ``description``) stored in
+the :class:`~app.models.Skill` table. This module holds everything that isn't a route:
+slug/format helpers, SKILL.md (YAML frontmatter) parse/render for interop with the
+Anthropic Agent Skills format, visibility-scoped queries, the two prompt builders
+(explicit invocation + progressive-disclosure listing), and the first-boot seeds.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import yaml
+from sqlalchemy.orm import Session
+
+from app.models import Skill
+
+logger = logging.getLogger(__name__)
+
+#: hard caps so a pathological skill can't blow up the system prompt
+MAX_NAME_LEN = 100
+MAX_DESCRIPTION_LEN = 1_000
+MAX_INSTRUCTIONS_LEN = 60_000
+
+
+def slugify(name: str) -> str:
+    """Normalize a skill name to its slash-command slug ("Data Analysis!" -> "data-analysis")."""
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug[:MAX_NAME_LEN]
+
+
+# -- SKILL.md interop ---------------------------------------------------------
+def parse_skill_md(text: str) -> dict:
+    """Parse an Agent Skills SKILL.md file (YAML frontmatter + markdown body).
+
+    Returns ``{name, description, instructions}``. Raises ``ValueError`` on files that
+    don't carry the required frontmatter fields.
+    """
+    match = re.match(r"\A\s*---\s*\n(.*?)\n---\s*\n?(.*)\Z", text, re.DOTALL)
+    if not match:
+        raise ValueError("Not a SKILL.md file: missing '---' YAML frontmatter block")
+    try:
+        meta = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML frontmatter: {e}") from e
+    if not isinstance(meta, dict):
+        raise ValueError("Invalid frontmatter: expected a YAML mapping")
+    name = slugify(str(meta.get("name") or ""))
+    description = str(meta.get("description") or "").strip()
+    if not name:
+        raise ValueError("Frontmatter is missing the required 'name' field")
+    if not description:
+        raise ValueError("Frontmatter is missing the required 'description' field")
+    return {
+        "name": name,
+        "description": description[:MAX_DESCRIPTION_LEN],
+        "instructions": match.group(2).strip()[:MAX_INSTRUCTIONS_LEN],
+    }
+
+
+def render_skill_md(skill: Skill) -> str:
+    """Render a skill back to the portable SKILL.md format (for export)."""
+    meta = yaml.safe_dump(
+        {"name": skill.name, "description": skill.description},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ).strip()
+    return f"---\n{meta}\n---\n\n{skill.instructions}\n"
+
+
+# -- queries ------------------------------------------------------------------
+def visible_skills(db: Session, user_id: str | None, *, include_inactive: bool = False) -> list[Skill]:
+    """Active skills this user may see/invoke: public ones + their own."""
+    q = db.query(Skill)
+    if not include_inactive:
+        q = q.filter(Skill.is_active.is_(True))
+    q = q.filter((Skill.visibility == "public") | (Skill.created_by == user_id))
+    return q.order_by(Skill.name).all()
+
+
+def resolve_skill(db: Session, name: str, user_id: str | None) -> Skill | None:
+    """Look up one visible, active skill by slug. Visibility is the security boundary:
+    never inject a skill this user couldn't list."""
+    s = db.query(Skill).filter(Skill.name == slugify(name), Skill.is_active.is_(True)).first()
+    if not s or (s.visibility != "public" and s.created_by != user_id):
+        return None
+    return s
+
+
+# -- prompt builders ----------------------------------------------------------
+INVOKED_SKILL_PROMPT = """
+
+The user explicitly invoked the skill "{name}" (/{name}) for the current message. Follow
+these skill instructions for this turn; they take precedence over your general approach
+(but never over safety or system rules):
+
+<skill name="{name}">
+{instructions}
+</skill>
+"""
+
+SKILLS_PREAMBLE = """
+
+## Skills
+Registered skills teach you specialized workflows. Each entry below is name: trigger.
+When the user's request matches a skill's trigger, call the `use_skill` tool with the
+skill's name to load its full instructions BEFORE attempting the task. Load only the
+skills you actually need for the current request; skip them for unrelated requests.
+
+Available skills:
+{listing}
+"""
+
+
+def invoked_skills_prompt(skills: list[Skill]) -> str:
+    """Full-instruction blocks for skills the user explicitly invoked this turn."""
+    return "".join(
+        INVOKED_SKILL_PROMPT.format(name=s.name, instructions=s.instructions) for s in skills
+    )
+
+
+def skills_preamble(db: Session, user_id: str | None, *, exclude: set[str] = frozenset()) -> str:
+    """The progressive-disclosure listing (name + description only) for auto-activation.
+
+    Returns "" when there is nothing to advertise, so callers can also use it to decide
+    whether to expose the ``use_skill`` tool at all.
+    """
+    rows = [
+        s for s in visible_skills(db, user_id)
+        if s.auto_activate and s.name not in exclude
+    ]
+    if not rows:
+        return ""
+    listing = "\n".join(f"- {s.name}: {s.description}" for s in rows)
+    return SKILLS_PREAMBLE.format(listing=listing)
+
+
+# -- first-boot seeds ---------------------------------------------------------
+_SEED_SKILLS: list[dict] = [
+    {
+        "name": "data-analysis",
+        "description": (
+            "Structured exploratory data analysis of an uploaded or generated dataset "
+            "(CSV/JSON/Excel). Use when the user asks to analyze, profile, or find "
+            "patterns/trends in data, or asks questions a dataset in the workspace can answer."
+        ),
+        "instructions": """# Data Analysis
+
+Run a disciplined, reproducible analysis with `execute_python`. Never eyeball raw data and
+guess — compute.
+
+## Workflow
+1. **Profile first.** Load the data with pandas and print: shape, dtypes, null counts,
+   duplicates, and `describe()` for numeric columns. State data-quality caveats up front.
+2. **Frame the question.** Restate the user's question as one or more measurable
+   quantities before writing analysis code.
+3. **Analyze.** Prefer simple, verifiable aggregations (groupby, value_counts,
+   correlations) over clever one-liners. Print intermediate results so the numbers in
+   your answer are traceable to output.
+4. **Visualize.** Save 1–3 matplotlib charts as PNG files in the workspace (they surface
+   as artifacts). Label axes and titles; one message per chart.
+5. **Report.** Lead with the answer, then the supporting numbers, then caveats
+   (sample size, nulls dropped, assumptions made).
+
+## Rules
+- Never fabricate numbers — every figure you state must appear in executed output.
+- If the dataset is missing or unreadable, say exactly what you need instead of inventing data.
+""",
+    },
+    {
+        "name": "deep-research",
+        "description": (
+            "Multi-source web research with citations. Use when the user asks for a "
+            "researched answer, comparison, or report on a current/factual topic and web "
+            "search is enabled for the turn."
+        ),
+        "instructions": """# Deep Research
+
+Produce a sourced answer, not a from-memory essay. Requires the `web_search` and
+`web_fetch` tools; if web search is not enabled this turn, say so and ask the user to
+enable it rather than answering from memory.
+
+## Workflow
+1. **Decompose** the question into 2–5 concrete sub-questions.
+2. **Search broadly**: run a distinct `web_search` per sub-question; prefer primary
+   sources (docs, papers, official announcements) over aggregators.
+3. **Read deeply**: `web_fetch` the 3–6 most promising results. Skim for the specific
+   claims you need; note publication dates.
+4. **Cross-check**: any load-bearing fact should appear in at least two independent
+   sources, or be flagged as single-source.
+5. **Write up**: synthesized answer first, then key findings with inline numbered
+   citations, then a Sources list mapping numbers to URLs. Note disagreements between
+   sources explicitly.
+
+## Rules
+- Cite every non-obvious claim; never cite a page you did not fetch.
+- Prefer recent sources for fast-moving topics and say when information may be stale.
+""",
+    },
+    {
+        "name": "web-app",
+        "description": (
+            "Build a polished single-file HTML/CSS/JS web app or interactive visualization "
+            "as an artifact. Use when the user asks for a small app, game, dashboard, "
+            "calculator, or interactive demo."
+        ),
+        "instructions": """# Single-File Web App
+
+Build the app as **one self-contained `.html` file** written to the workspace with
+`write_file` — it renders live in the artifact canvas.
+
+## Workflow
+1. Confirm the core interaction in one sentence (in your head, not by asking) and pick
+   the simplest structure that supports it. No build steps, no frameworks.
+2. Write the full file in one `write_file` call: inline `<style>` and `<script>`,
+   semantic HTML, no external network dependencies (CDNs may be blocked).
+3. Test the logic that can be tested headlessly with `execute_node` (pure functions,
+   game rules) before declaring it done.
+4. Iterate with `edit_file` rather than rewriting the whole file for small fixes.
+
+## Quality bar
+- Responsive layout (flex/grid, relative units); usable on a narrow viewport.
+- Respect `prefers-color-scheme` for dark/light.
+- Keyboard support for anything clickable; visible focus states.
+- Handle empty/error states — no dead buttons or NaN displays.
+""",
+    },
+]
+
+
+def seed_builtin_skills(db: Session) -> None:
+    """Seed the example skills once (first boot, empty table). Users can edit/delete
+    them freely afterwards — this never re-creates rows."""
+    if db.query(Skill.id).first() is not None:
+        return
+    for spec in _SEED_SKILLS:
+        db.add(Skill(**spec, visibility="public", created_by=None, auto_activate=True))
+    db.commit()
+    logger.info("Seeded %d example skills", len(_SEED_SKILLS))

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1,0 +1,259 @@
+"""Agent skills: CRUD, visibility, SKILL.md import/export, chat injection, use_skill."""
+import pytest
+
+
+def _make_skill(client, **overrides):
+    body = {
+        "name": "commit-poet",
+        "description": "Write commit messages as haiku. Use when asked for a commit message.",
+        "instructions": "# Commit Poet\n\nWrite every commit message as a haiku (5-7-5).",
+        "visibility": "public",
+        **overrides,
+    }
+    r = client.post("/api/skills", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _cleanup(client):
+    for s in client.get("/api/skills").json():
+        client.delete(f"/api/skills/{s['id']}")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(client):
+    _cleanup(client)
+    yield
+    _cleanup(client)
+
+
+# -- CRUD ---------------------------------------------------------------------
+def test_skill_crud_roundtrip(client):
+    s = _make_skill(client)
+    assert s["name"] == "commit-poet"
+    assert s["auto_activate"] is True
+    assert s["created_by"] == "local"
+
+    listed = client.get("/api/skills").json()
+    assert any(x["id"] == s["id"] for x in listed)
+
+    r = client.patch(f"/api/skills/{s['id']}", json={"description": "Updated trigger"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["description"] == "Updated trigger"
+    assert body["instructions"].startswith("# Commit Poet")  # untouched by partial PATCH
+
+    assert client.delete(f"/api/skills/{s['id']}").status_code == 200
+    assert client.get(f"/api/skills/{s['id']}").status_code == 404
+
+
+def test_skill_name_slugified_and_unique(client):
+    s = _make_skill(client, name="  Commit Poet!! ")
+    assert s["name"] == "commit-poet"
+
+    r = client.post(
+        "/api/skills",
+        json={"name": "Commit  Poet", "description": "dup", "instructions": "x"},
+    )
+    assert r.status_code == 409
+
+    r = client.post("/api/skills", json={"name": "!!!", "description": "d", "instructions": "x"})
+    assert r.status_code == 422
+
+
+def test_skill_validators(client):
+    r = client.post("/api/skills", json={"name": "x", "description": "d", "instructions": "i",
+                                         "visibility": "sneaky"})
+    assert r.status_code == 422
+    r = client.post("/api/skills", json={"name": "x", "description": "   ", "instructions": "i"})
+    assert r.status_code == 422
+
+
+# -- visibility ----------------------------------------------------------------
+def test_visibility_filtering(client, db):
+    from app.models import User
+    from app.routers.skills import list_skills
+    from app.skills import resolve_skill
+
+    _make_skill(client, name="public-skill")
+    _make_skill(client, name="private-skill", visibility="private")
+
+    viewer = User(id="u-viewer", username="viewer", role="user")
+    names = {s.name for s in list_skills(db=db, user=viewer)}
+    assert "public-skill" in names
+    assert "private-skill" not in names  # someone else's private skill is hidden
+
+    # resolve_skill (the chat/tool injection path) enforces the same boundary.
+    assert resolve_skill(db, "private-skill", "u-viewer") is None
+    assert resolve_skill(db, "public-skill", "u-viewer") is not None
+
+    admin = User(id="local", username="local", role="admin")
+    names = {s.name for s in list_skills(db=db, user=admin)}
+    assert {"public-skill", "private-skill"} <= names
+
+
+def test_non_admin_cannot_publish(client, db):
+    from app.models import User
+    from app.routers.skills import _create
+    from app.schemas import SkillCreate
+
+    plain = User(id="u-plain", username="bob", role="user")
+    s = _create(
+        db,
+        SkillCreate(name="bobs-skill", description="d", instructions="i", visibility="public"),
+        plain,
+    )
+    assert s.visibility == "private"  # silently forced private for non-admins
+    db.delete(s)
+    db.commit()
+
+
+# -- SKILL.md interop -----------------------------------------------------------
+SKILL_MD = """---
+name: PDF Wrangler
+description: Extract text and tables from PDF files. Use when the user provides a PDF.
+---
+
+# PDF Wrangler
+
+Use `execute_python` with pypdf to extract text.
+"""
+
+
+def test_import_and_export_skill_md(client):
+    r = client.post("/api/skills/import", files={"file": ("SKILL.md", SKILL_MD, "text/markdown")})
+    assert r.status_code == 200, r.text
+    s = r.json()
+    assert s["name"] == "pdf-wrangler"
+    assert s["description"].startswith("Extract text and tables")
+    assert s["instructions"].startswith("# PDF Wrangler")
+
+    r = client.get(f"/api/skills/{s['id']}/export")
+    assert r.status_code == 200
+    text = r.text
+    assert text.startswith("---\n")
+    assert "name: pdf-wrangler" in text
+    assert "# PDF Wrangler" in text
+
+    # Exported file round-trips through the parser.
+    from app.skills import parse_skill_md
+
+    parsed = parse_skill_md(text)
+    assert parsed["name"] == "pdf-wrangler"
+
+
+def test_import_rejects_bad_files(client):
+    r = client.post("/api/skills/import", files={"file": ("x.md", "no frontmatter here", "text/markdown")})
+    assert r.status_code == 422
+    r = client.post(
+        "/api/skills/import",
+        files={"file": ("x.md", "---\ndescription: only\n---\nbody", "text/markdown")},
+    )
+    assert r.status_code == 422  # missing name
+
+
+# -- chat integration ------------------------------------------------------------
+class CaptureProvider:
+    model = "capture"
+    supports_tools = True
+
+    def __init__(self, log):
+        self.log = log
+
+    def stream(self, messages, tools, params):  # noqa: ARG002
+        from app.providers.base import StreamDelta
+
+        self.log.append({"messages": messages, "tools": {t.name for t in tools}, "params": params})
+        yield StreamDelta(type="text", text="ok")
+        yield StreamDelta(type="done", stop_reason="stop")
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    import app.routers.chat as chat_router
+
+    log = []
+    monkeypatch.setattr(chat_router, "build_provider", lambda profile, model=None: CaptureProvider(log))
+    monkeypatch.setattr(chat_router, "_build_fallback", lambda active_profile: None)
+    return log
+
+
+def test_explicit_skill_injects_instructions(client, capture):
+    _make_skill(client)
+
+    r = client.post("/api/chat", json={"message": "commit msg please", "skills": ["commit-poet"]})
+    assert r.status_code == 200
+    assert capture
+
+    system = capture[-1]["messages"][0]["content"]
+    assert 'invoked the skill "commit-poet"' in system
+    assert "Write every commit message as a haiku" in system  # full instructions, this turn
+
+    # The user message records the invocation so history keeps a marker + UI shows a chip.
+    conv_id = [m for m in capture[-1]["messages"] if m["role"] == "user"]
+    assert conv_id  # sanity
+    convs = client.get("/api/conversations").json()
+    detail = client.get(f"/api/conversations/{convs[0]['id']}").json()
+    user_msg = [m for m in detail["messages"] if m["role"] == "user"][-1]
+    assert {"type": "skill", "name": "commit-poet"}.items() <= {
+        k: v for k, v in (user_msg["attachments"] or [{}])[0].items() if k in ("type", "name")
+    }.items()
+
+
+def test_auto_skills_preamble_and_tool(client, capture):
+    _make_skill(client)
+
+    r = client.post("/api/chat", json={"message": "hello"})
+    assert r.status_code == 200
+    system = capture[-1]["messages"][0]["content"]
+    assert "## Skills" in system
+    assert "- commit-poet:" in system
+    assert "Write every commit message as a haiku" not in system  # description only
+    assert "use_skill" in capture[-1]["tools"]
+
+
+def test_skills_disabled_strips_preamble_and_tool(client, capture):
+    _make_skill(client)
+
+    r = client.post("/api/chat", json={"message": "hello", "skills_enabled": False})
+    assert r.status_code == 200
+    system = capture[-1]["messages"][0]["content"]
+    assert "## Skills" not in system
+    assert "use_skill" not in capture[-1]["tools"]
+
+
+def test_no_skills_hides_use_skill_tool(client, capture):
+    r = client.post("/api/chat", json={"message": "hello"})
+    assert r.status_code == 200
+    assert "## Skills" not in capture[-1]["messages"][0]["content"]
+    assert "use_skill" not in capture[-1]["tools"]
+
+
+def test_auto_activate_false_not_advertised_but_invocable(client, capture):
+    _make_skill(client, auto_activate=False)
+
+    r = client.post("/api/chat", json={"message": "hello"})
+    assert r.status_code == 200
+    assert "- commit-poet:" not in capture[-1]["messages"][0]["content"]
+
+    r = client.post("/api/chat", json={"message": "msg", "skills": ["commit-poet"]})
+    assert r.status_code == 200
+    assert 'invoked the skill "commit-poet"' in capture[-1]["messages"][0]["content"]
+
+
+# -- use_skill tool ---------------------------------------------------------------
+def test_use_skill_tool(client, db, tmp_path):
+    from app.agent.tools.base import ToolContext
+    from app.agent.tools.skills import UseSkill
+
+    _make_skill(client)
+    ctx = ToolContext(
+        conversation_id="c1", workspace=tmp_path, db=db, runner=None, user_id="local"
+    )
+    result = UseSkill().run(ctx, name="commit-poet")
+    assert not result.is_error
+    assert "haiku" in result.content
+
+    result = UseSkill().run(ctx, name="nope")
+    assert result.is_error
+    assert "commit-poet" in result.content  # lists what IS available

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -1,0 +1,114 @@
+# Agent Skills
+
+Skills are named, reusable markdown instructions that teach the agent a specialized
+workflow — "how we do data analysis here", "how to write a research report", "how to build
+a single-file web app". They follow the [Anthropic Agent Skills](https://github.com/anthropics/skills)
+model and are import/export-compatible with its `SKILL.md` format, adapted to Phlox's
+database-backed, multi-user architecture.
+
+A skill is two things:
+
+- a **description** — what the skill does *and when to use it*. This is the activation
+  trigger: it's all the model sees until the skill is actually loaded.
+- **instructions** — the full markdown workflow the model follows once the skill is active.
+
+Phlox seeds three example skills on first boot (`data-analysis`, `deep-research`,
+`web-app`); edit or delete them freely.
+
+## Using skills
+
+### Explicit: slash commands
+
+Type `/` at the start of the composer to open the skill picker (arrow keys + Enter, or
+click). The chosen skill appears as a chip above the composer; the rest of your text is
+the actual message:
+
+```
+/deep-research what changed in the EU AI Act this year?
+```
+
+The skill's **full instructions are injected into the system prompt for that turn**, and
+the message is recorded with the invocation so the history keeps an `[Invoked skills: …]`
+marker (later turns don't re-pay the full instruction cost; the model can reload a skill
+with `use_skill` if it needs it again).
+
+### Automatic: the agent picks (progressive disclosure)
+
+When the **Skills** toggle under the composer is on (the default), the system prompt
+lists every auto-activatable skill as *name + description only*, and the model gets a
+`use_skill` tool to load a skill's full instructions when a request matches its trigger.
+Unused skills cost almost no context — this is the same progressive-disclosure design
+Claude Code uses.
+
+Turn the toggle off to hide the listing and the tool for that message. Per-skill, the
+**"Agent may auto-activate"** flag controls whether a skill is advertised at all — turn it
+off for skills that should only ever run when explicitly invoked with `/`.
+
+`use_skill` is a regular tool: it appears in the admin **Tools** panel with the usual
+`auto | ask | deny` permission policy, and assistants with the *Agent tools* capability
+disabled never see it (explicit `/` invocation still works there — it's just prompt text).
+
+## Managing skills
+
+**Settings → Skills.** Every user can create, edit, and delete their own skills
+(`private` — visible and invocable only by them). Admins can additionally publish
+**public** skills available to everyone, and manage all skills.
+
+| Field | Meaning |
+|---|---|
+| Name | Slug handle (`data-analysis`); what users type after `/`. Unique, auto-slugified. |
+| Description | What it does + when to use it. Drives auto-activation; make it specific. |
+| Instructions | Markdown workflow followed once active. |
+| Agent may auto-activate | Advertise to the model for self-serve loading. |
+| Visibility | `private` (creator only) / `public` (admin-only setting). |
+
+### Import / export (SKILL.md)
+
+Skills interoperate with the [Agent Skills format](https://github.com/anthropics/skills):
+YAML frontmatter (`name`, `description`) + markdown body. **Import SKILL.md** in the
+Skills panel accepts any such file — including skills from the community ecosystem — and
+each skill row has an export button that downloads it back in the same format.
+
+```markdown
+---
+name: commit-poet
+description: Write commit messages as haiku. Use when asked for a commit message.
+---
+
+# Commit Poet
+
+Write every commit message as a haiku (5-7-5).
+```
+
+One deliberate difference from Claude Code's skills: Phlox skills are **instructions
+only** — bundled resource files/scripts aren't stored with the skill. The agent's
+sandboxed workspace tools (`write_file`, `execute_python`, …) let a skill *create* any
+scripts it needs at run time instead.
+
+## Writing good skills
+
+- Put the *when* in the description — the model decides to activate on the description
+  alone. "Analyze data" triggers poorly; "Use when the user asks to analyze, profile, or
+  find patterns in a dataset" triggers well.
+- Write instructions as a numbered workflow with hard rules ("never state a number that
+  isn't in executed output"), not prose.
+- Keep instructions focused; a skill that tries to cover everything activates for nothing.
+- Skills are injected into the system prompt, so they consume context — the caps are
+  1,000 chars for descriptions and 60,000 for instructions, but shorter is better.
+
+## How it works (internals)
+
+- `backend/app/models.py` — `Skill` table (slug, description, instructions,
+  `auto_activate`, `visibility`, `created_by`).
+- `backend/app/skills.py` — SKILL.md parse/render, visibility queries, the two prompt
+  builders, first-boot seeds.
+- `backend/app/routers/skills.py` — `/api/skills` CRUD + `/import` + `/{id}/export`.
+- `backend/app/agent/tools/skills.py` — the `use_skill` tool.
+- `backend/app/routers/chat.py` — per-turn injection: full instructions for `/`-invoked
+  skills, the name+description listing for auto-activation, and the `use_skill`
+  enable/disable decision.
+- Frontend: `Composer.jsx` (slash picker, chips, Skills toggle),
+  `settings/SkillsPanel.jsx` (management UI).
+
+Visibility is enforced server-side on every path (listing, `/` invocation, `use_skill`):
+a user can never activate another user's private skill.

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -81,6 +81,20 @@ export const api = {
     return res.json()
   },
 
+  // skills (users manage their own; admins can publish public ones)
+  listSkills: () => req('GET', '/api/skills'),
+  createSkill: (body) => req('POST', '/api/skills', body),
+  updateSkill: (id, body) => req('PATCH', `/api/skills/${id}`, body),
+  deleteSkill: (id) => req('DELETE', `/api/skills/${id}`),
+  importSkill: async (file) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch('/api/skills/import', { method: 'POST', body: fd, headers: { ...authHeaders() } })
+    if (!res.ok) throw new Error(await res.text())
+    return res.json()
+  },
+  exportSkillUrl: (id) => `/api/skills/${id}/export`,
+
   // mcp
   listMcp: () => req('GET', '/api/mcp'),
   addMcp: (body) => req('POST', '/api/mcp', body),

--- a/frontend/src/components/chat/Composer.jsx
+++ b/frontend/src/components/chat/Composer.jsx
@@ -11,6 +11,7 @@ import {
   FileText,
   Loader2,
   AlertCircle,
+  Sparkles,
 } from 'lucide-react'
 import { useStore } from '../../store/useStore'
 import { api } from '../../api/client'
@@ -46,6 +47,12 @@ export default function Composer() {
   const [documentRefs, setDocumentRefs] = useState([])
   const [docPicker, setDocPicker] = useState({ open: false, query: '', start: 0, end: 0 })
   const [activeDocIndex, setActiveDocIndex] = useState(0)
+  // Skills invoked for this message ("/name" picker) + the auto-activation toggle.
+  const [skillRefs, setSkillRefs] = useState([])
+  const [skillsEnabled, setSkillsEnabled] = useState(true)
+  const [skillPicker, setSkillPicker] = useState({ open: false, query: '', end: 0 })
+  const [activeSkillIndex, setActiveSkillIndex] = useState(0)
+  const skills = useStore((s) => s.skills)
   const streaming = useStore((s) => s.streaming)
   const send = useStore((s) => s.sendMessage)
   const stop = useStore((s) => s.stopStreaming)
@@ -58,6 +65,8 @@ export default function Composer() {
   const caps = assistants.find((a) => a.id === activeAssistantId)?.capabilities || {}
   const webSearchAllowed = caps.web_search !== false
   const documentSearchAllowed = caps.document_search !== false
+  // Auto-activation rides on the use_skill tool, so it needs the tools capability.
+  const skillsAllowed = caps.tools !== false
   const taRef = useRef(null)
   const fileRef = useRef(null)
   const imgRef = useRef(null)
@@ -79,6 +88,8 @@ export default function Composer() {
   useEffect(() => {
     setDocumentRefs([])
     setDocPicker({ open: false, query: '', start: 0, end: 0 })
+    setSkillRefs([])
+    setSkillPicker({ open: false, query: '', end: 0 })
     loadDocuments()
   }, [activeId, loadDocuments])
 
@@ -91,6 +102,21 @@ export default function Composer() {
   useEffect(() => {
     setActiveDocIndex(0)
   }, [docPicker.open, docPicker.query])
+
+  useEffect(() => {
+    setActiveSkillIndex(0)
+  }, [skillPicker.open, skillPicker.query])
+
+  const pickerSkills = useMemo(() => {
+    if (!skillPicker.open) return []
+    const q = skillPicker.query.toLowerCase()
+    const selected = new Set(skillRefs.map((s) => s.id))
+    return skills
+      .filter((s) => s.is_active !== false)
+      .filter((s) => !selected.has(s.id))
+      .filter((s) => !q || s.name.includes(q) || (s.description || '').toLowerCase().includes(q))
+      .slice(0, 7)
+  }, [skillPicker.open, skillPicker.query, skillRefs, skills])
 
   const pickerDocs = useMemo(() => {
     if (!docPicker.open) return []
@@ -107,13 +133,20 @@ export default function Composer() {
   const erroredDocs = documentRefs.filter((d) => d.status === 'error')
   const documentIds = documentRefs.map((d) => d.id || d.document_id).filter(Boolean)
   const canSubmit =
-    (text.trim() || images.length > 0 || documentIds.length > 0) &&
+    (text.trim() || images.length > 0 || documentIds.length > 0 || skillRefs.length > 0) &&
     !uploading &&
     pendingDocs.length === 0 &&
     erroredDocs.length === 0
 
   const updateMentionPicker = (value, cursor) => {
     const before = value.slice(0, cursor)
+    // "/" at the very start of the message opens the skill (slash command) picker.
+    const slash = /^\/([a-zA-Z0-9-]*)$/.exec(before)
+    if (slash && skills.length > 0) {
+      setSkillPicker({ open: true, query: slash[1] || '', end: cursor })
+    } else {
+      setSkillPicker((prev) => (prev.open ? { open: false, query: '', end: 0 } : prev))
+    }
     const match = /(^|\s)@([^\s@]*)$/.exec(before)
     if (!match) {
       setDocPicker((prev) => (prev.open ? { open: false, query: '', start: 0, end: 0 } : prev))
@@ -135,6 +168,18 @@ export default function Composer() {
     setDocumentRefs((prev) =>
       prev.some((d) => (d.id || d.document_id) === doc.id) ? prev : [...prev, doc],
     )
+  }
+
+  const pickSkill = (skill) => {
+    setSkillRefs((prev) => (prev.some((s) => s.id === skill.id) ? prev : [...prev, skill]))
+    // The "/query" text is replaced by the chip; what remains is the actual message.
+    setText((prev) => prev.slice(skillPicker.end))
+    setSkillPicker({ open: false, query: '', end: 0 })
+    window.setTimeout(() => {
+      taRef.current?.focus()
+      taRef.current?.setSelectionRange(0, 0)
+      setTextareaHeight()
+    }, 0)
   }
 
   const pickDocument = (doc) => {
@@ -162,15 +207,42 @@ export default function Composer() {
       images,
       documentIds,
       documentRefs,
+      skills: skillRefs.map((s) => s.name),
+      skillRefs,
+      skillsEnabled: skillsEnabled && skillsAllowed,
     })
     setText('')
     setImages([])
     setDocumentRefs([])
     setDocPicker({ open: false, query: '', start: 0, end: 0 })
+    setSkillRefs([])
+    setSkillPicker({ open: false, query: '', end: 0 })
     if (taRef.current) taRef.current.style.height = 'auto'
   }
 
   const onKeyDown = (e) => {
+    if (skillPicker.open) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setSkillPicker({ open: false, query: '', end: 0 })
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveSkillIndex((i) => Math.min(i + 1, Math.max(pickerSkills.length - 1, 0)))
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveSkillIndex((i) => Math.max(i - 1, 0))
+        return
+      }
+      if ((e.key === 'Enter' || e.key === 'Tab') && pickerSkills.length > 0) {
+        e.preventDefault()
+        pickSkill(pickerSkills[activeSkillIndex] || pickerSkills[0])
+        return
+      }
+    }
     if (docPicker.open) {
       if (e.key === 'Escape') {
         e.preventDefault()
@@ -265,6 +337,27 @@ export default function Composer() {
             ))}
           </div>
         )}
+        {skillRefs.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {skillRefs.map((skill) => (
+              <div
+                key={skill.id}
+                className="flex max-w-full items-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-2.5 py-1.5 text-xs text-content"
+                title={skill.description || skill.name}
+              >
+                <Sparkles size={14} className="shrink-0 text-accent" />
+                <span className="max-w-[16rem] truncate font-medium">/{skill.name}</span>
+                <button
+                  onClick={() => setSkillRefs((prev) => prev.filter((s) => s.id !== skill.id))}
+                  className="rounded p-0.5 text-muted hover:text-red-600"
+                  title="Remove"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         {documentRefs.length > 0 && (
           <div className="mb-2 flex flex-wrap gap-2">
             {documentRefs.map((doc) => {
@@ -303,6 +396,32 @@ export default function Composer() {
                 </div>
               )
             })}
+          </div>
+        )}
+        {skillPicker.open && (
+          <div className="mb-2 max-h-56 overflow-y-auto rounded-lg border border-border bg-surface shadow-lg">
+            {pickerSkills.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-muted">No matching skills</div>
+            ) : (
+              pickerSkills.map((skill, i) => (
+                <button
+                  key={skill.id}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    pickSkill(skill)
+                  }}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${
+                    i === activeSkillIndex ? 'bg-surface-2 text-content' : 'text-content hover:bg-surface-2'
+                  }`}
+                  title={skill.description}
+                >
+                  <Sparkles size={15} className="shrink-0 text-accent" />
+                  <span className="shrink-0 font-medium">/{skill.name}</span>
+                  <span className="min-w-0 flex-1 truncate text-xs text-muted">{skill.description}</span>
+                </button>
+              ))
+            )}
           </div>
         )}
         {docPicker.open && (
@@ -413,6 +532,21 @@ export default function Composer() {
                 className="rounded border-border text-accent focus:ring-accent" />
               <FileSearch size={12} /> Search documents
             </label>
+            {skills.length > 0 && (
+              <label
+                className={`flex items-center gap-1.5 ${skillsAllowed ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}
+                title={
+                  skillsAllowed
+                    ? 'Let the agent load registered skills on its own (type / to invoke one explicitly)'
+                    : 'Disabled by this assistant'
+                }
+              >
+                <input type="checkbox" checked={skillsEnabled && skillsAllowed} disabled={!skillsAllowed}
+                  onChange={(e) => setSkillsEnabled(e.target.checked)}
+                  className="rounded border-border text-accent focus:ring-accent" />
+                <Sparkles size={12} /> Skills
+              </label>
+            )}
           </div>
           <TokenMeter />
         </div>

--- a/frontend/src/components/chat/Message.jsx
+++ b/frontend/src/components/chat/Message.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Copy, Check, Brain, Pencil, RefreshCw, FileText } from 'lucide-react'
+import { Copy, Check, Brain, Pencil, RefreshCw, FileText, Sparkles } from 'lucide-react'
 import Markdown from '../markdown/Markdown'
 import ToolCallCard from './ToolCallCard'
 import ArtifactViewer from './ArtifactViewer'
@@ -52,6 +52,7 @@ export default function Message({ message, conversationId, isLast }) {
   if (message.role === 'user') {
     const images = (message.attachments || []).filter((a) => a.type === 'image')
     const documents = (message.attachments || []).filter((a) => a.type === 'document')
+    const skillRefs = (message.attachments || []).filter((a) => a.type === 'skill')
     const canEdit = !streaming && !String(message.id).startsWith('tmp-')
     if (editing) {
       return (
@@ -102,6 +103,20 @@ export default function Message({ message, conversationId, isLast }) {
                 >
                   <FileText size={14} className="shrink-0 text-accent" />
                   <span className="truncate">{doc.filename || 'Document'}</span>
+                </div>
+              ))}
+            </div>
+          )}
+          {skillRefs.length > 0 && (
+            <div className="flex max-w-full flex-wrap justify-end gap-2">
+              {skillRefs.map((s) => (
+                <div
+                  key={s.skill_id || s.name}
+                  className="flex max-w-[18rem] items-center gap-1.5 rounded-lg border border-accent/40 bg-accent/10 px-2.5 py-1.5 text-xs text-content"
+                  title={`Invoked skill: ${s.name}`}
+                >
+                  <Sparkles size={14} className="shrink-0 text-accent" />
+                  <span className="truncate font-medium">/{s.name}</span>
                 </div>
               ))}
             </div>

--- a/frontend/src/components/settings/SettingsDrawer.jsx
+++ b/frontend/src/components/settings/SettingsDrawer.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal, Wallet, Bot } from 'lucide-react'
+import { X, Cpu, Palette, FileText, Server, Wrench, Brain, Users, ShieldCheck, KeyRound, KeySquare, BarChart3, SlidersHorizontal, Wallet, Bot, Sparkles } from 'lucide-react'
 import ProviderSettings from './ProviderSettings'
 import AssistantsPanel from './AssistantsPanel'
 import ThemeSwitcher from './ThemeSwitcher'
@@ -10,6 +10,7 @@ import ConfigPanel from './ConfigPanel'
 import BudgetsPanel from './BudgetsPanel'
 import AuthSettingsPanel from './AuthSettingsPanel'
 import ApiKeysPanel from './ApiKeysPanel'
+import SkillsPanel from './SkillsPanel'
 import DocumentsPanel from '../documents/DocumentsPanel'
 import McpManager from '../mcp/McpManager'
 import ToolManager from '../tools/ToolManager'
@@ -21,6 +22,7 @@ const USER_TABS = [
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'documents', label: 'Documents', icon: FileText },
   { id: 'memory', label: 'Memory', icon: Brain },
+  { id: 'skills', label: 'Skills', icon: Sparkles },
   { id: 'apikeys', label: 'API Keys', icon: KeySquare },
 ]
 const ADMIN_TABS = [
@@ -186,6 +188,7 @@ export default function SettingsDrawer({ initialTab = 'providers', onClose }) {
             {tab === 'appearance' && <ThemeSwitcher />}
             {tab === 'documents' && <DocumentsPanel />}
             {tab === 'memory' && <MemoryPanel />}
+            {tab === 'skills' && <SkillsPanel />}
             {tab === 'apikeys' && <ApiKeysPanel />}
             {isAdmin && tab === 'assistants' && <AssistantsPanel />}
             {isAdmin && tab === 'mcp' && <McpManager />}

--- a/frontend/src/components/settings/SkillsPanel.jsx
+++ b/frontend/src/components/settings/SkillsPanel.jsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react'
+import { Sparkles, Plus, Trash2, Pencil, X, Upload, Download, Loader2 } from 'lucide-react'
+import { api } from '../../api/client'
+import { useStore } from '../../store/useStore'
+import { authHeaders } from '../../api/token'
+
+const BLANK = {
+  name: '',
+  description: '',
+  instructions: '',
+  auto_activate: true,
+  visibility: 'private',
+}
+
+function Field({ label, hint, children }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs font-medium text-content">{label}</span>
+      {children}
+      {hint && <span className="mt-1 block text-[11px] text-muted">{hint}</span>}
+    </label>
+  )
+}
+
+const inputCls =
+  'w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-content outline-none focus:border-accent'
+
+export default function SkillsPanel() {
+  const user = useStore((s) => s.user)
+  const refreshStoreSkills = useStore((s) => s.loadSkills)
+  const isAdmin = user?.role === 'admin'
+  const [skills, setSkills] = useState([])
+  const [editing, setEditing] = useState(null) // null | {id?, ...form}
+  const [saving, setSaving] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [error, setError] = useState(null)
+
+  const load = () => api.listSkills().then(setSkills).catch(() => setSkills([]))
+  useEffect(() => { load() }, [])
+
+  const refresh = async () => {
+    await load()
+    refreshStoreSkills() // keep the composer "/" picker in sync
+  }
+
+  const save = async () => {
+    if (!editing?.name.trim() || !editing?.description.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      const body = {
+        name: editing.name,
+        description: editing.description,
+        instructions: editing.instructions,
+        auto_activate: editing.auto_activate,
+        visibility: editing.visibility,
+      }
+      if (editing.id) await api.updateSkill(editing.id, body)
+      else await api.createSkill(body)
+      setEditing(null)
+      await refresh()
+    } catch (e) {
+      setError(String(e.message || e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const remove = async (skill) => {
+    if (!window.confirm(`Delete the skill "/${skill.name}"?`)) return
+    await api.deleteSkill(skill.id)
+    await refresh()
+  }
+
+  const onImport = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setImporting(true)
+    setError(null)
+    try {
+      await api.importSkill(file)
+      await refresh()
+    } catch (err) {
+      setError(String(err.message || err))
+    } finally {
+      setImporting(false)
+      e.target.value = ''
+    }
+  }
+
+  const exportSkill = async (skill) => {
+    const res = await fetch(api.exportSkillUrl(skill.id), { headers: { ...authHeaders() } })
+    if (!res.ok) return
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${skill.name}-SKILL.md`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const canEdit = (skill) => isAdmin || skill.created_by === user?.username || skill.created_by === user?.id
+
+  return (
+    <div>
+      <h3 className="mb-1 text-sm font-semibold text-content">Skills</h3>
+      <p className="mb-4 text-xs text-muted">
+        Reusable instructions the agent follows for specialized tasks. Invoke one explicitly by
+        typing <code className="rounded bg-surface-3 px-1">/</code> in the composer, or let the
+        agent load relevant skills on its own (the <em>Skills</em> toggle under the composer).
+        Compatible with the Anthropic{' '}
+        <code className="rounded bg-surface-3 px-1">SKILL.md</code> format for import/export.
+      </p>
+
+      {error && (
+        <div className="mb-3 rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-4 flex gap-2">
+        <button
+          onClick={() => { setError(null); setEditing({ ...BLANK }) }}
+          className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm text-accent-fg hover:opacity-90"
+        >
+          <Plus size={15} /> New skill
+        </button>
+        <label className="flex cursor-pointer items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-content hover:border-accent">
+          <input type="file" accept=".md,.markdown,text/markdown" className="hidden" onChange={onImport} disabled={importing} />
+          {importing ? <Loader2 size={15} className="animate-spin" /> : <Upload size={15} />}
+          Import SKILL.md
+        </label>
+      </div>
+
+      {editing && (
+        <div className="mb-4 space-y-3 rounded-xl border border-border bg-surface p-4">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-semibold text-content">
+              {editing.id ? `Edit /${editing.name}` : 'New skill'}
+            </h4>
+            <button onClick={() => setEditing(null)} className="rounded p-1 text-muted hover:text-content">
+              <X size={15} />
+            </button>
+          </div>
+          <Field label="Name" hint="Lowercase slug; users invoke it as /name.">
+            <input value={editing.name} onChange={(e) => setEditing({ ...editing, name: e.target.value })}
+              placeholder="data-analysis" className={inputCls} />
+          </Field>
+          <Field
+            label="Description"
+            hint="What it does AND when to use it — this is how the model decides to activate the skill."
+          >
+            <textarea value={editing.description} rows={2}
+              onChange={(e) => setEditing({ ...editing, description: e.target.value })}
+              placeholder="Structured analysis of tabular data. Use when the user asks to analyze a dataset."
+              className={inputCls} />
+          </Field>
+          <Field label="Instructions" hint="Markdown workflow the agent follows once the skill is active.">
+            <textarea value={editing.instructions} rows={10}
+              onChange={(e) => setEditing({ ...editing, instructions: e.target.value })}
+              placeholder={'# My Skill\n\n1. Do this first…'}
+              className={`${inputCls} font-mono text-xs`} />
+          </Field>
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-content">
+            <label className="flex cursor-pointer items-center gap-1.5" title="List this skill in the agent's prompt so it can load it on its own">
+              <input type="checkbox" checked={editing.auto_activate}
+                onChange={(e) => setEditing({ ...editing, auto_activate: e.target.checked })}
+                className="rounded border-border text-accent focus:ring-accent" />
+              Agent may auto-activate
+            </label>
+            {isAdmin && (
+              <label className="flex items-center gap-1.5">
+                Visibility
+                <select value={editing.visibility}
+                  onChange={(e) => setEditing({ ...editing, visibility: e.target.value })}
+                  className="rounded-lg border-border bg-surface text-xs text-content focus:border-accent focus:ring-accent">
+                  <option value="private">private (only me)</option>
+                  <option value="public">public (everyone)</option>
+                </select>
+              </label>
+            )}
+          </div>
+          <div className="flex justify-end gap-2">
+            <button onClick={() => setEditing(null)} className="rounded-lg px-3 py-1.5 text-xs text-muted hover:text-content">
+              Cancel
+            </button>
+            <button onClick={save} disabled={saving || !editing.name.trim() || !editing.description.trim()}
+              className="rounded-lg bg-accent px-3 py-1.5 text-xs text-accent-fg hover:opacity-90 disabled:opacity-50">
+              {saving ? 'Saving…' : editing.id ? 'Save changes' : 'Create skill'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {skills.length === 0 && <p className="text-sm text-muted">No skills yet.</p>}
+        {skills.map((s) => (
+          <div key={s.id} className="flex items-start gap-3 rounded-lg border border-border bg-surface px-3 py-2">
+            <Sparkles size={16} className="mt-0.5 shrink-0 text-accent" />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-content">/{s.name}</span>
+                <span className={`rounded px-1.5 py-0.5 text-[10px] ${
+                  s.visibility === 'public' ? 'bg-hutch-cyan/15 text-hutch-cyan' : 'bg-surface-3 text-muted'
+                }`}>
+                  {s.visibility}
+                </span>
+                {s.auto_activate && (
+                  <span className="rounded bg-hutch-purple/15 px-1.5 py-0.5 text-[10px] text-hutch-purple">
+                    auto
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 line-clamp-2 text-xs text-muted">{s.description}</div>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <button onClick={() => exportSkill(s)} className="rounded p-1.5 text-muted hover:text-accent" title="Export SKILL.md">
+                <Download size={15} />
+              </button>
+              {canEdit(s) && (
+                <>
+                  <button onClick={() => { setError(null); setEditing({ ...BLANK, ...s }) }}
+                    className="rounded p-1.5 text-muted hover:text-accent" title="Edit">
+                    <Pencil size={15} />
+                  </button>
+                  <button onClick={() => remove(s)} className="rounded p-1.5 text-muted hover:text-red-600" title="Delete">
+                    <Trash2 size={15} />
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/store/useStore.js
+++ b/frontend/src/store/useStore.js
@@ -17,6 +17,8 @@ export const useStore = create((set, get) => ({
   settings: null,
   providers: [],
   assistants: [],
+  // Registered agent skills (public + own), for the "/" composer picker.
+  skills: [],
   // Assistant for the active conversation (pinned server-side) or the pending new chat.
   activeAssistantId: null,
   theme: initialTheme(),
@@ -70,8 +72,17 @@ export const useStore = create((set, get) => ({
   async loadApp() {
     await Promise.all([
       get().loadConversations(), get().loadSettings(), get().loadProviders(), get().loadBudget(),
-      get().loadAssistants(),
+      get().loadAssistants(), get().loadSkills(),
     ])
+  },
+
+  async loadSkills() {
+    try {
+      const skills = await api.listSkills()
+      set({ skills })
+    } catch {
+      set({ skills: [] })
+    }
   },
 
   async loadAssistants() {
@@ -230,12 +241,20 @@ export const useStore = create((set, get) => ({
       images = [],
       documentIds = [],
       documentRefs = [],
+      skills = [],
+      skillRefs = [],
+      skillsEnabled = true,
     } = {},
   ) {
-    if (!text.trim() && images.length === 0 && documentIds.length === 0) return
+    if (!text.trim() && images.length === 0 && documentIds.length === 0 && skills.length === 0) return
     // Steering: if a turn is in flight, queue this as a follow-up to send when it finishes.
     if (get().streaming) {
-      set({ queued: { text, images, documentIds, documentRefs, autoApprove, webSearch, documentSearch } })
+      set({
+        queued: {
+          text, images, documentIds, documentRefs, autoApprove, webSearch, documentSearch,
+          skills, skillRefs, skillsEnabled,
+        },
+      })
       return
     }
     const attachments = [
@@ -249,6 +268,7 @@ export const useStore = create((set, get) => ({
         n_chunks: doc.n_chunks,
         status: doc.status,
       })),
+      ...skillRefs.map((s) => ({ type: 'skill', skill_id: s.id, name: s.name })),
     ]
     const userMsg = {
       id: `tmp-${Date.now()}`,
@@ -271,6 +291,8 @@ export const useStore = create((set, get) => ({
       document_search: documentSearch,
       document_ids: documentIds,
       images,
+      skills,
+      skills_enabled: skillsEnabled,
       // Only meaningful for a new conversation; the server pins it there and ignores
       // it on existing ones.
       assistant_id: get().activeAssistantId,
@@ -447,6 +469,9 @@ export const useStore = create((set, get) => ({
         images: q.images,
         documentIds: q.documentIds || [],
         documentRefs: q.documentRefs || [],
+        skills: q.skills || [],
+        skillRefs: q.skillRefs || [],
+        skillsEnabled: q.skillsEnabled !== false,
       })
     }
   },


### PR DESCRIPTION
# Add Agent Skills — reusable, invokable workflows for the agent

## Summary

Adds an **Agent Skills** system to Phlox: named, reusable markdown instructions the agent can follow for specialized tasks (data analysis, research, building a web app, etc.), compatible with [Anthropic's Agent Skills / `SKILL.md` format](https://github.com/anthropics/skills) for easy import/export.

Two ways to activate a skill:

- **Explicit** — type `/` in the composer to open a skill picker (same UX as the existing `@` document picker). The chosen skill becomes a chip; its full instructions are injected into the system prompt for that turn.
- **Automatic (progressive disclosure)** — a new **Skills** toggle under the composer (on by default) advertises registered skills to the model as *name + trigger description only*, and gives it a `use_skill` tool to load full instructions on demand when a request matches. This keeps unused skills nearly free in context, the same design Claude Code itself uses.

Skills are managed in a new **Settings → Skills** panel: users create/edit/delete their own (private by default); admins can publish shared ones for everyone. The panel supports importing any community `SKILL.md` file and exporting skills back to that same format.

Three example skills (`data-analysis`, `deep-research`, `web-app`) are seeded on first boot and can be freely edited or deleted.

## Why this design

Phlox is multi-user and database-backed, unlike Claude Code's single-user filesystem model, so skills are stored as rows (like assistants/MCP servers) rather than folders on disk — with the same visibility rules (`private`/`public`) already used elsewhere in the app. Bundled resource *files* (scripts, templates) from the original spec are intentionally out of scope: a skill's instructions can just tell the agent to write whatever scripts it needs via the existing sandboxed workspace tools (`write_file`, `execute_python`, …), so there's no need for a second file-bundling mechanism.

## Backend changes

- `Skill` model (`name`, `description`, `instructions`, `auto_activate`, `visibility`, `created_by`).
- `app/skills.py` — slug/format helpers, `SKILL.md` parse/render, visibility-scoped queries, the two prompt builders (explicit-invocation block vs. progressive-disclosure listing), first-boot seeds.
- `app/routers/skills.py` — `/api/skills` CRUD, `/api/skills/import`, `/api/skills/{id}/export`.
- `app/agent/tools/skills.py` — the `use_skill` tool (loads a skill's full instructions by name; enforces the same visibility boundary as the REST routes).
- `routers/chat.py` — injects invoked skills' full instructions, builds the auto-activation listing, gates the `use_skill` tool, and records skill invocations as message attachments so history/regenerate/UI all reflect what was used.
- `ChatRequest` gains `skills: list[str]` (explicit invocations) and `skills_enabled: bool` (auto-activation toggle).

## Frontend changes

- `Composer.jsx` — `/` slash-command picker (keyboard nav, same pattern as `@` docs), skill chips, **Skills** toggle.
- `Message.jsx` — renders an invoked-skill chip on sent messages.
- `SkillsPanel.jsx` (new) — full CRUD UI, import/export, auto-activate + visibility controls.
- `SettingsDrawer.jsx` — new "Skills" tab.
- `useStore.js` / `client.js` — skills state, API bindings, wiring through `sendMessage` and the queued-follow-up path.

## Testing

- 13 new backend tests (`tests/test_skills.py`): CRUD, visibility boundaries (private skills stay hidden from other users, including via `resolve_skill`), non-admin publish restriction, `SKILL.md` import/export round-trip, chat-turn injection (explicit + auto), tool gating, and the `use_skill` tool directly.
- Full backend suite passes (131 tests), `ruff check` clean on all changed files.
- Frontend: `vite build` passes.
- Manually verified end-to-end in a live dev instance: created a skill via the UI, invoked it with `/name`, confirmed the model received and followed the injected instructions (produced a haiku-formatted response per the test skill's rules), no console errors.
